### PR TITLE
Remove Chisel2 Compatibility mode

### DIFF
--- a/src/main/scala/devices/chiplink/Bundles.scala
+++ b/src/main/scala/devices/chiplink/Bundles.scala
@@ -2,27 +2,27 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util.{UIntToOH, OHToUInt, Cat}
-import freechips.rocketchip.util.{rightOR,GenericParameterizedBundle}
+import freechips.rocketchip.util.{rightOR}
 
-class WideDataLayerPortLane(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
+class WideDataLayerPortLane(val params: ChipLinkParams) extends Bundle {
   val clk  = Output(Clock())
   val rst  = Output(Bool())
   val send = Output(Bool())
   val data = Output(UInt(params.dataBits.W))
 }
 
-class WideDataLayerPort(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
+class WideDataLayerPort(val params: ChipLinkParams) extends Bundle {
   val c2b = new WideDataLayerPortLane(params)
   val b2c = Flipped(new WideDataLayerPortLane(params))
 }
 
-class DataLayer(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
+class DataLayer(val params: ChipLinkParams) extends Bundle {
   val data = Output(UInt(params.dataBits.W))
   val last = Output(Bool())
   val beats = Output(UInt((params.xferBits + 1).W))
 }
 
-class CreditBump(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
+class CreditBump(val params: ChipLinkParams) extends Bundle {
   val a = Output(UInt(params.creditBits.W))
   val b = Output(UInt(params.creditBits.W))
   val c = Output(UInt(params.creditBits.W))

--- a/src/main/scala/devices/chiplink/Bundles.scala
+++ b/src/main/scala/devices/chiplink/Bundles.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util.{UIntToOH, OHToUInt, Cat}
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.{rightOR,GenericParameterizedBundle}
 
 class WideDataLayerPortLane(params: ChipLinkParams) extends GenericParameterizedBundle(params) {

--- a/src/main/scala/devices/chiplink/Bundles.scala
+++ b/src/main/scala/devices/chiplink/Bundles.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{UIntToOH}
+import chisel3.util.{UIntToOH, OHToUInt, Cat}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.{rightOR,GenericParameterizedBundle}
 

--- a/src/main/scala/devices/chiplink/Bundles.scala
+++ b/src/main/scala/devices/chiplink/Bundles.scala
@@ -1,33 +1,34 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{UIntToOH}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.{rightOR,GenericParameterizedBundle}
 
 class WideDataLayerPortLane(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
-  val clk  = Clock(OUTPUT)
-  val rst  = Bool(OUTPUT)
-  val send = Bool(OUTPUT)
-  val data = UInt(OUTPUT, width=params.dataBits)
+  val clk  = Output(Clock())
+  val rst  = Output(Bool())
+  val send = Output(Bool())
+  val data = Output(UInt(params.dataBits.W))
 }
 
 class WideDataLayerPort(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
   val c2b = new WideDataLayerPortLane(params)
-  val b2c = new WideDataLayerPortLane(params).flip
+  val b2c = Flipped(new WideDataLayerPortLane(params))
 }
 
 class DataLayer(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
-  val data = UInt(OUTPUT, width=params.dataBits)
-  val last = Bool(OUTPUT)
-  val beats = UInt(OUTPUT, width=params.xferBits + 1)
+  val data = Output(UInt(params.dataBits.W))
+  val last = Output(Bool())
+  val beats = Output(UInt((params.xferBits + 1).W))
 }
 
 class CreditBump(params: ChipLinkParams) extends GenericParameterizedBundle(params) {
-  val a = UInt(OUTPUT, width = params.creditBits)
-  val b = UInt(OUTPUT, width = params.creditBits)
-  val c = UInt(OUTPUT, width = params.creditBits)
-  val d = UInt(OUTPUT, width = params.creditBits)
-  val e = UInt(OUTPUT, width = params.creditBits)
+  val a = Output(UInt(params.creditBits.W))
+  val b = Output(UInt(params.creditBits.W))
+  val c = Output(UInt(params.creditBits.W))
+  val d = Output(UInt(params.creditBits.W))
+  val e = Output(UInt(params.creditBits.W))
   def X: Seq[UInt] = Seq(a, b, c, d, e)
 
   // saturating addition
@@ -35,7 +36,7 @@ class CreditBump(params: ChipLinkParams) extends GenericParameterizedBundle(para
     val out = Wire(new CreditBump(params))
     (out.X zip (X zip that.X)) foreach { case (o, (x, y)) =>
       val z = x +& y
-      o := Mux((z >> params.creditBits).orR, ~UInt(0, width=params.creditBits), z)
+      o := Mux((z >> params.creditBits).orR, ~0.U(params.creditBits.W), z)
     }
     out
   }
@@ -46,7 +47,7 @@ class CreditBump(params: ChipLinkParams) extends GenericParameterizedBundle(para
       val mask = rightOR(x) >> 1
       val msbOH = ~(~x | mask)
       val msb = OHToUInt(msbOH << 1, params.creditBits + 1) // 0 = 0, 1 = 1, 2 = 4, 3 = 8, ...
-      val pad = (msb | UInt(0, width=5))(4,0)
+      val pad = (msb | 0.U(5.W))(4,0)
       (pad, x & mask)
     }
     val (a_msb, a_rest) = msb(a)
@@ -56,8 +57,8 @@ class CreditBump(params: ChipLinkParams) extends GenericParameterizedBundle(para
     val (e_msb, e_rest) = msb(e)
     val header = Cat(
       e_msb, d_msb, c_msb, b_msb, a_msb,
-      UInt(0, width = 4), // padding
-      UInt(5, width = 3))
+      0.U(4.W), // padding
+      5.U(3.W))
 
     val out = Wire(new CreditBump(params))
     out.a := a_rest
@@ -71,7 +72,7 @@ class CreditBump(params: ChipLinkParams) extends GenericParameterizedBundle(para
 
 object CreditBump {
   def apply(params: ChipLinkParams, x: Int): CreditBump = {
-    val v = UInt(x, width = params.creditBits)
+    val v = x.U(params.creditBits.W)
     val out = Wire(new CreditBump(params))
     out.X.foreach { _ := v }
     out
@@ -79,8 +80,8 @@ object CreditBump {
 
   def apply(params: ChipLinkParams, header: UInt): CreditBump = {
     def convert(x: UInt) =
-      Mux(x > UInt(params.creditBits),
-          ~UInt(0, width = params.creditBits),
+      Mux(x > params.creditBits.U,
+          ~0.U(params.creditBits.W),
           UIntToOH(x, params.creditBits + 1) >> 1)
     val out = Wire(new CreditBump(params))
     out.a := convert(header(11,  7))

--- a/src/main/scala/devices/chiplink/CAM.scala
+++ b/src/main/scala/devices/chiplink/CAM.scala
@@ -24,14 +24,14 @@ class CAM(keys: Int, dataBits: Int) extends Module
   io.key := OHToUInt(free_sel, keys)
 
   io.alloc.ready := free.orR
-  when (io.alloc.fire()) { data.write(io.key, io.alloc.bits) }
+  when (io.alloc.fire) { data.write(io.key, io.alloc.bits) }
 
   // Support free in same cycle as alloc
-  val bypass = io.alloc.fire() && io.free.bits === io.key
+  val bypass = io.alloc.fire && io.free.bits === io.key
   io.data := Mux(bypass, io.alloc.bits, data(io.free.bits))
 
   // Update CAM usage
-  val clr = Mux(io.alloc.fire(), free_sel, 0.U)
+  val clr = Mux(io.alloc.fire, free_sel, 0.U)
   val set = Mux(io.free.valid, UIntToOH(io.free.bits), 0.U)
   free := (free & ~clr) | set
 }

--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
@@ -84,12 +84,12 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val bypass = Bool(OUTPUT)
+      val bypass = Output(Bool())
       // When not syncTX, these drive the TX domain
-      val c2b_clk = Clock(INPUT)
-      val c2b_rst = Bool(INPUT)
+      val c2b_clk = Input(Clock())
+      val c2b_rst = Input(Bool())
       // If fpgaReset, we need a pulse that arrives before b2c_clk locks
-      val fpga_reset = if (params.fpgaReset) Some(Bool(INPUT)) else None
+      val fpga_reset = if (params.fpgaReset) Some(Input(Bool())) else None
     })
     val port = ioNode.bundle
 
@@ -165,7 +165,7 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
     io.fpga_reset match {
       case None =>
         // b2c.rst is actually synchronous to b2c.clk, so one flop is enough
-        rx.reset := AsyncResetReg(Bool(false), port.b2c.clk, port.b2c.rst, true, None)
+        rx.reset := AsyncResetReg(false.B, port.b2c.clk, port.b2c.rst, true, None)
       case Some(resetPulse) =>
         // For high performance, FPGA IO buffer registers must feed IO into D, not reset
         // However, FPGA registers also support an initial block to generate a reset pulse

--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -225,7 +225,7 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
     sinkE.io.d_clSink := sourceD.io.e_clSink
 
     // Disable ChipLink while RX+TX are in reset
-    val do_bypass = ResetCatchAndSync(clock, rx.reset) || ResetCatchAndSync(clock, tx.reset)
+    val do_bypass = ResetCatchAndSync(clock, rx.reset.asBool) || ResetCatchAndSync(clock, tx.reset.asBool)
     sbypass.module.io.bypass := do_bypass
     mbypass.module.io.bypass := do_bypass
     io.bypass := do_bypass

--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{log2Ceil, log2Up, UIntToOH}
+import chisel3.util.{log2Ceil, log2Up, UIntToOH, Cat, DecoupledIO}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{log2Ceil, log2Up, UIntToOH}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
@@ -69,14 +70,14 @@ case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge,
     val maxKey = m.keys.max
     val maxVal = m.values.max
     val valBits = log2Up(maxVal + 1)
-    val out = Wire(Vec(maxKey + 1, UInt(width = valBits)))
-    m.foreach { case (k, v) => out(k) := UInt(v, width = valBits) }
+    val out = Wire(Vec(maxKey + 1, UInt(valBits.W)))
+    m.foreach { case (k, v) => out(k) := v.U(valBits.W) }
     out
   }
 
   // Packet format; little-endian
   def encode(format: UInt, opcode: UInt, param: UInt, size: UInt, domain: UInt, source: UInt): UInt = {
-    def fmt(x: UInt, w: Int) = (x | UInt(0, width=w))(w-1, 0)
+    def fmt(x: UInt, w: Int) = (x | 0.U(w.W))(w-1, 0)
     Cat(
       fmt(source, 16),
       fmt(domain, 3),
@@ -98,12 +99,12 @@ case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge,
 
   def size2beats(size: UInt): UInt = {
     val shift = log2Ceil(params.dataBytes)
-    Cat(UIntToOH(size|UInt(0, width=4), params.xferBits + 1) >> (shift + 1), size <= UInt(shift))
+    Cat(UIntToOH(size|0.U(4.W), params.xferBits + 1) >> (shift + 1), size <= shift.U)
   }
 
   def mask2beats(size: UInt): UInt = {
     val shift = log2Ceil(params.dataBytes*8)
-    Cat(UIntToOH(size|UInt(0, width=4), params.xferBits + 1) >> (shift + 1), size <= UInt(shift))
+    Cat(UIntToOH(size|0.U(4.W), params.xferBits + 1) >> (shift + 1), size <= shift.U)
   }
 
   def beats1(x: UInt, forceFormat: Option[UInt] = None): UInt = {
@@ -112,21 +113,21 @@ case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge,
     val masks = mask2beats(size)
     val grant = opcode === TLMessages.Grant || opcode === TLMessages.GrantData
     val partial = opcode === TLMessages.PutPartialData
-    val a = Mux(opcode(2), UInt(0), beats) + UInt(2) + Mux(partial, masks, UInt(0))
-    val b = Mux(opcode(2), UInt(0), beats) + UInt(2) + Mux(partial, masks, UInt(0))
-    val c = Mux(opcode(0), beats, UInt(0)) + UInt(2)
-    val d = Mux(opcode(0), beats, UInt(0)) + grant.asUInt
-    val e = UInt(0)
-    val f = UInt(0)
-    Vec(a, b, c, d, e, f)(forceFormat.getOrElse(format))
+    val a = Mux(opcode(2), 0.U, beats) + 2.U + Mux(partial, masks, 0.U)
+    val b = Mux(opcode(2), 0.U, beats) + 2.U + Mux(partial, masks, 0.U)
+    val c = Mux(opcode(0), beats, 0.U) + 2.U
+    val d = Mux(opcode(0), beats, 0.U) + grant.asUInt
+    val e = 0.U
+    val f = 0.U
+    VecInit(a, b, c, d, e, f)(forceFormat.getOrElse(format))
   }
 
   def firstlast(x: DecoupledIO[UInt], forceFormat: Option[UInt] = None): (Bool, Bool) = {
-    val count = RegInit(UInt(0))
+    val count = RegInit(0.U)
     val beats = beats1(x.bits, forceFormat)
-    val first = count === UInt(0)
-    val last  = count === UInt(1) || (first && beats === UInt(0))
-    when (x.fire) { count := Mux(first, beats, count - UInt(1)) }
+    val first = count === 0.U
+    val last  = count === 1.U || (first && beats === 0.U)
+    when (x.fire) { count := Mux(first, beats, count - 1.U) }
     (first, last)
   }
 
@@ -134,7 +135,7 @@ case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge,
   def makeError(legal: Bool, address: UInt): UInt = {
     val alignBits = log2Ceil(errorDev.alignment)
     Cat(
-      Mux(legal, address, UInt(errorDev.base))(params.addressBits-1, alignBits),
+      Mux(legal, address, errorDev.base.U)(params.addressBits-1, alignBits),
       address(alignBits-1, 0))
   }
 }

--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util.{log2Ceil, log2Up, UIntToOH, Cat, DecoupledIO}
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -126,7 +126,7 @@ case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge,
     val beats = beats1(x.bits, forceFormat)
     val first = count === UInt(0)
     val last  = count === UInt(1) || (first && beats === UInt(0))
-    when (x.fire()) { count := Mux(first, beats, count - UInt(1)) }
+    when (x.fire) { count := Mux(first, beats, count - UInt(1)) }
     (first, last)
   }
 

--- a/src/main/scala/devices/chiplink/Partial.scala
+++ b/src/main/scala/devices/chiplink/Partial.scala
@@ -42,7 +42,7 @@ class ParitalExtractor[T <: TLDataChannel](gen: T) extends Module
     }
 
     // Update the FSM
-    when (io.i.fire()) {
+    when (io.i.fire) {
       shift := Mux(empty, i_data, wide >> 36)
       state := state - UInt(1)
       when (empty)   { state := UInt(8) }
@@ -93,7 +93,7 @@ class PartialInjector[T <: TLDataChannel](gen: T) extends Module
     }
 
     // Update the FSM
-    when (io.o.fire()) {
+    when (io.o.fire) {
       shift := wide >> 32
       state := state + UInt(1)
       when (full || last) {

--- a/src/main/scala/devices/chiplink/Partial.scala
+++ b/src/main/scala/devices/chiplink/Partial.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.Decoupled
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -10,7 +10,7 @@ class ParitalExtractor[T <: TLDataChannel](gen: T) extends Module
 {
   val io = new Bundle {
     val last = Input(Bool())
-    val i = Decoupled(gen).flip
+    val i = Flipped(Decoupled(gen))
     val o = Decoupled(gen)
   }
 

--- a/src/main/scala/devices/chiplink/Partial.scala
+++ b/src/main/scala/devices/chiplink/Partial.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.Decoupled
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -8,7 +9,7 @@ import freechips.rocketchip.util._
 class ParitalExtractor[T <: TLDataChannel](gen: T) extends Module
 {
   val io = new Bundle {
-    val last = Bool(INPUT)
+    val last = Input(Bool())
     val i = Decoupled(gen).flip
     val o = Decoupled(gen)
   }
@@ -25,28 +26,28 @@ class ParitalExtractor[T <: TLDataChannel](gen: T) extends Module
     case b: TLBundleB => (b.data, b.mask)
   }
 
-  val state  = RegInit(UInt(0, width=4)) // number of nibbles; [0,8]
-  val shift  = Reg(UInt(width=32))
+  val state  = RegInit(0.U(4.W)) // number of nibbles; [0,8]
+  val shift  = Reg(UInt(32.W))
   val enable = i_opcode === TLMessages.PutPartialData
-  val empty  = state === UInt(0)
+  val empty  = state === 0.U
 
   when (enable) {
     val wide = shift | (i_data << (state << 2))
-    o_data := Vec.tabulate(4) { i => wide(9*(i+1)-1, 9*i+1) } .asUInt
-    o_mask := Vec.tabulate(4) { i => wide(9*i) } .asUInt
+    o_data := VecInit.tabulate(4) { i => wide(9*(i+1)-1, 9*i+1) } .asUInt
+    o_mask := VecInit.tabulate(4) { i => wide(9*i) } .asUInt
 
     // Swallow beat if we have no nibbles
     when (empty) {
-      io.i.ready := Bool(true)
-      io.o.valid := Bool(false)
+      io.i.ready := true.B
+      io.o.valid := false.B
     }
 
     // Update the FSM
     when (io.i.fire) {
       shift := Mux(empty, i_data, wide >> 36)
-      state := state - UInt(1)
-      when (empty)   { state := UInt(8) }
-      when (io.last) { state := UInt(0) }
+      state := state - 1.U
+      when (empty)   { state := 8.U }
+      when (io.last) { state := 0.U }
     }
   }
 }
@@ -54,9 +55,9 @@ class ParitalExtractor[T <: TLDataChannel](gen: T) extends Module
 class PartialInjector[T <: TLDataChannel](gen: T) extends Module
 {
   val io = new Bundle {
-    val i_last = Bool(INPUT)
-    val o_last = Bool(OUTPUT)
-    val i = Decoupled(gen).flip
+    val i_last = Input(Bool())
+    val o_last = Output(Bool())
+    val i = Flipped(Decoupled(gen))
     val o = Decoupled(gen)
   }
 
@@ -72,12 +73,12 @@ class PartialInjector[T <: TLDataChannel](gen: T) extends Module
     case b: TLBundleB => b.data
   }
 
-  val state = RegInit(UInt(0, width=4)) // number of nibbles; [0,8]
-  val shift = RegInit(UInt(0, width=32))
+  val state = RegInit(0.U(4.W)) // number of nibbles; [0,8]
+  val shift = RegInit(0.U(32.W))
   val full  = state(3)
   val partial = i_opcode === TLMessages.PutPartialData
 
-  val last = RegInit(Bool(false))
+  val last = RegInit(false.B)
   io.o_last := Mux(partial, last, io.i_last)
 
   when (partial) {
@@ -89,16 +90,16 @@ class PartialInjector[T <: TLDataChannel](gen: T) extends Module
 
     // Inject a beat
     when ((io.i_last || full) && !last) {
-      io.i.ready := Bool(false)
+      io.i.ready := false.B
     }
 
     // Update the FSM
     when (io.o.fire) {
       shift := wide >> 32
-      state := state + UInt(1)
+      state := state + 1.U
       when (full || last) {
-        state := UInt(0)
-        shift := UInt(0)
+        state := 0.U
+        shift := 0.U
       }
       last := io.i_last && !last
     }

--- a/src/main/scala/devices/chiplink/Partial.scala
+++ b/src/main/scala/devices/chiplink/Partial.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/RX.scala
+++ b/src/main/scala/devices/chiplink/RX.scala
@@ -33,7 +33,7 @@ class RX(info: ChipLinkInfo) extends Module
   // Select the correct HellaQueue for the request
   val (first, _) = info.firstlast(beat)
   val formatBits  = beat.bits(2, 0)
-  val formatValid = beat.fire() && first
+  val formatValid = beat.fire && first
   val format = Mux(formatValid, formatBits, RegEnable(formatBits, formatValid))
   val formatOH = UIntToOH(format)
 
@@ -77,7 +77,7 @@ class RX(info: ChipLinkInfo) extends Module
   // Generate new RX credits as the HellaQueues drain
   val rxInc = Wire(new CreditBump(info.params))
   (hqX zip rxInc.X) foreach { case (hq, inc) =>
-    inc := hq.io.deq.fire().asUInt
+    inc := hq.io.deq.fire.asUInt
   }
 
   // Generate new TX credits as we receive F-format messages
@@ -86,8 +86,8 @@ class RX(info: ChipLinkInfo) extends Module
   // As we hand-over credits, reset the counters
   tx := tx + txInc
   rx := rx + rxInc
-  when (txOut.fire()) { tx := txInc }
-  when (rxOut.fire()) { rx := rxInc }
+  when (txOut.fire) { tx := txInc }
+  when (rxOut.fire) { rx := rxInc }
 }
 
 /*

--- a/src/main/scala/devices/chiplink/RX.scala
+++ b/src/main/scala/devices/chiplink/RX.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{UIntToOH, Decoupled}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._

--- a/src/main/scala/devices/chiplink/RX.scala
+++ b/src/main/scala/devices/chiplink/RX.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{UIntToOH, Decoupled}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -8,27 +9,27 @@ import freechips.rocketchip.util._
 class RX(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val b2c_send = Bool(INPUT)
-    val b2c_data = UInt(INPUT, info.params.dataBits)
-    val a = new AsyncBundle(UInt(width = info.params.dataBits), info.params.crossing)
-    val b = new AsyncBundle(UInt(width = info.params.dataBits), info.params.crossing)
-    val c = new AsyncBundle(UInt(width = info.params.dataBits), info.params.crossing)
-    val d = new AsyncBundle(UInt(width = info.params.dataBits), info.params.crossing)
-    val e = new AsyncBundle(UInt(width = info.params.dataBits), info.params.crossing)
+    val b2c_send = Input(Bool())
+    val b2c_data = Input(UInt(info.params.dataBits.W))
+    val a = new AsyncBundle(UInt(info.params.dataBits.W), info.params.crossing)
+    val b = new AsyncBundle(UInt(info.params.dataBits.W), info.params.crossing)
+    val c = new AsyncBundle(UInt(info.params.dataBits.W), info.params.crossing)
+    val d = new AsyncBundle(UInt(info.params.dataBits.W), info.params.crossing)
+    val e = new AsyncBundle(UInt(info.params.dataBits.W), info.params.crossing)
     val rxc = new AsyncBundle(new CreditBump(info.params), AsyncQueueParams.singleton())
     val txc = new AsyncBundle(new CreditBump(info.params), AsyncQueueParams.singleton())
   }
 
   // Immediately register our input data
   val b2c_data = RegNext(RegNext(io.b2c_data))
-  val b2c_send = RegNext(RegNext(io.b2c_send), Bool(false))
+  val b2c_send = RegNext(RegNext(io.b2c_send), false.B)
   // b2c_send is NOT cleared on the first RegNext because this module's reset has a flop on it
 
   // Fit b2c into the firstlast API
-  val beat = Wire(Decoupled(UInt(width = info.params.dataBits)))
+  val beat = Wire(Decoupled(UInt(info.params.dataBits.W)))
   beat.bits  := b2c_data
   beat.valid := b2c_send
-  beat.ready := Bool(true)
+  beat.ready := true.B
 
   // Select the correct HellaQueue for the request
   val (first, _) = info.firstlast(beat)
@@ -67,8 +68,8 @@ class RX(info: ChipLinkInfo) extends Module
   // Constantly transmit credit updates
   val txOut = Wire(Decoupled(new CreditBump(info.params)))
   val rxOut = Wire(Decoupled(new CreditBump(info.params)))
-  txOut.valid := Bool(true)
-  rxOut.valid := Bool(true)
+  txOut.valid := true.B
+  rxOut.valid := true.B
   txOut.bits := tx
   rxOut.bits := rx
   io.txc <> ToAsyncBundle(txOut, AsyncQueueParams.singleton())

--- a/src/main/scala/devices/chiplink/RX.scala
+++ b/src/main/scala/devices/chiplink/RX.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SinkA.scala
+++ b/src/main/scala/devices/chiplink/SinkA.scala
@@ -32,7 +32,7 @@ class SinkA(info: ChipLinkInfo) extends Module
   val s_address1 = UInt(2, width = 2)
   val s_data     = UInt(3, width = 2)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := s_address0 }
       is (s_address0) { state := s_address1 }

--- a/src/main/scala/devices/chiplink/SinkA.scala
+++ b/src/main/scala/devices/chiplink/SinkA.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkA(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkA.scala
+++ b/src/main/scala/devices/chiplink/SinkA.scala
@@ -1,13 +1,14 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Queue}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkA(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val a = Decoupled(new TLBundleA(info.edgeIn.bundle)).flip
+    val a = Flipped(Decoupled(new TLBundleA(info.edgeIn.bundle)))
     val q = Decoupled(new DataLayer(info.params))
   }
 
@@ -26,11 +27,11 @@ class SinkA(info: ChipLinkInfo) extends Module
   val a_partial = a.bits.opcode === TLMessages.PutPartialData
 
   // A simple FSM to generate the packet components
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_address0 = UInt(1, width = 2)
-  val s_address1 = UInt(2, width = 2)
-  val s_data     = UInt(3, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_address0 = 1.U(2.W)
+  val s_address1 = 2.U(2.W)
+  val s_data     = 3.U(2.W)
 
   when (io.q.fire) {
     switch (state) {
@@ -43,7 +44,7 @@ class SinkA(info: ChipLinkInfo) extends Module
 
   // Construct the header beat
   val header = info.encode(
-    format = UInt(0),
+    format = 0.U,
     opcode = a.bits.opcode,
     param  = a.bits.param,
     size   = a.bits.size,
@@ -59,9 +60,9 @@ class SinkA(info: ChipLinkInfo) extends Module
   a.ready := io.q.ready && isLastState
   io.q.valid := a.valid
   io.q.bits.last  := a_last && isLastState
-  io.q.bits.data  := Vec(header, address0, address1, a.bits.data)(state)
-  io.q.bits.beats := Mux(a_hasData, info.size2beats(a.bits.size), UInt(0)) + UInt(3) +
-                     Mux(a_partial, info.mask2beats(a.bits.size), UInt(0))
+  io.q.bits.data  := VecInit(header, address0, address1, a.bits.data)(state)
+  io.q.bits.beats := Mux(a_hasData, info.size2beats(a.bits.size), 0.U) + 3.U +
+                     Mux(a_partial, info.mask2beats(a.bits.size), 0.U)
 }
 
 /*

--- a/src/main/scala/devices/chiplink/SinkA.scala
+++ b/src/main/scala/devices/chiplink/SinkA.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Queue}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/devices/chiplink/SinkB.scala
+++ b/src/main/scala/devices/chiplink/SinkB.scala
@@ -27,7 +27,7 @@ class SinkB(info: ChipLinkInfo) extends Module
   val s_address1 = UInt(2, width = 2)
   val s_data     = UInt(3, width = 2)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := s_address0 }
       is (s_address0) { state := s_address1 }

--- a/src/main/scala/devices/chiplink/SinkB.scala
+++ b/src/main/scala/devices/chiplink/SinkB.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkB(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkB.scala
+++ b/src/main/scala/devices/chiplink/SinkB.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._
-import chisel3.util.{Decoupled, Queue}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/devices/chiplink/SinkB.scala
+++ b/src/main/scala/devices/chiplink/SinkB.scala
@@ -1,13 +1,14 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util.{Decoupled, Queue}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkB(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val b = Decoupled(new TLBundleB(info.edgeOut.bundle)).flip
+    val b = Flipped(Decoupled(new TLBundleB(info.edgeOut.bundle)))
     val q = Decoupled(new DataLayer(info.params))
   }
 
@@ -21,11 +22,11 @@ class SinkB(info: ChipLinkInfo) extends Module
   val b_partial = b.bits.opcode === TLMessages.PutPartialData
 
   // A simple FSM to generate the packet components
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_address0 = UInt(1, width = 2)
-  val s_address1 = UInt(2, width = 2)
-  val s_data     = UInt(3, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_address0 = 1.U(2.W)
+  val s_address1 = 2.U(2.W)
+  val s_data     = 3.U(2.W)
 
   when (io.q.fire) {
     switch (state) {
@@ -38,14 +39,14 @@ class SinkB(info: ChipLinkInfo) extends Module
 
   // Construct the header beat
   val header = info.encode(
-    format = UInt(1),
+    format = 1.U,
     opcode = b.bits.opcode,
     param  = b.bits.param,
     size   = b.bits.size,
-    domain = UInt(0), // ChipLink only allows one remote cache, in domain 0
-    source = UInt(0))
+    domain = 0.U, // ChipLink only allows one remote cache, in domain 0
+    source = 0.U)
 
-  assert (!b.valid || b.bits.source === UInt(0))
+  assert (!b.valid || b.bits.source === 0.U)
 
   // Construct the address beats
   val address0 = b.bits.address
@@ -56,9 +57,9 @@ class SinkB(info: ChipLinkInfo) extends Module
   b.ready := io.q.ready && isLastState
   io.q.valid := b.valid
   io.q.bits.last  := b_last && isLastState
-  io.q.bits.data  := Vec(header, address0, address1, b.bits.data)(state)
-  io.q.bits.beats := Mux(b_hasData, info.size2beats(b.bits.size), UInt(0)) + UInt(3) +
-                     Mux(b_partial, info.mask2beats(b.bits.size), UInt(0))
+  io.q.bits.data  := VecInit(header, address0, address1, b.bits.data)(state)
+  io.q.bits.beats := Mux(b_hasData, info.size2beats(b.bits.size), 0.U) + 3.U +
+                     Mux(b_partial, info.mask2beats(b.bits.size), 0.U)
 }
 
 /*

--- a/src/main/scala/devices/chiplink/SinkC.scala
+++ b/src/main/scala/devices/chiplink/SinkC.scala
@@ -29,7 +29,7 @@ class SinkC(info: ChipLinkInfo) extends Module
   val s_address1 = UInt(2, width = 2)
   val s_data     = UInt(3, width = 2)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := s_address0 }
       is (s_address0) { state := s_address1 }

--- a/src/main/scala/devices/chiplink/SinkC.scala
+++ b/src/main/scala/devices/chiplink/SinkC.scala
@@ -1,13 +1,14 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Queue}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkC(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val c = Decoupled(new TLBundleC(info.edgeIn.bundle)).flip
+    val c = Flipped(Decoupled(new TLBundleC(info.edgeIn.bundle)))
     val q = Decoupled(new DataLayer(info.params))
   }
 
@@ -23,11 +24,11 @@ class SinkC(info: ChipLinkInfo) extends Module
   val c_release = c.bits.opcode === TLMessages.Release || c.bits.opcode === TLMessages.ReleaseData
 
   // A simple FSM to generate the packet components
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_address0 = UInt(1, width = 2)
-  val s_address1 = UInt(2, width = 2)
-  val s_data     = UInt(3, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_address0 = 1.U(2.W)
+  val s_address1 = 2.U(2.W)
+  val s_data     = 3.U(2.W)
 
   when (io.q.fire) {
     switch (state) {
@@ -40,14 +41,14 @@ class SinkC(info: ChipLinkInfo) extends Module
 
   // Construct the header beat
   val header = info.encode(
-    format = UInt(2),
+    format = 2.U,
     opcode = c.bits.opcode,
     param  = c.bits.param,
     size   = c.bits.size,
-    domain = UInt(0), // only caches (unordered) can release
-    source = Mux(c_release, source(c.bits.source), UInt(0)))
+    domain = 0.U, // only caches (unordered) can release
+    source = Mux(c_release, source(c.bits.source), 0.U))
 
-  assert (!c.valid || domain(c.bits.source) === UInt(0))
+  assert (!c.valid || domain(c.bits.source) === 0.U)
 
   // Construct the address beats
   val address0 = c.bits.address
@@ -58,8 +59,8 @@ class SinkC(info: ChipLinkInfo) extends Module
   c.ready := io.q.ready && isLastState
   io.q.valid := c.valid
   io.q.bits.last  := c_last && isLastState
-  io.q.bits.data  := Vec(header, address0, address1, c.bits.data)(state)
-  io.q.bits.beats := Mux(c_hasData, info.size2beats(c.bits.size), UInt(0)) + UInt(3)
+  io.q.bits.data  := VecInit(header, address0, address1, c.bits.data)(state)
+  io.q.bits.beats := Mux(c_hasData, info.size2beats(c.bits.size), 0.U) + 3.U
 }
 
 /*

--- a/src/main/scala/devices/chiplink/SinkC.scala
+++ b/src/main/scala/devices/chiplink/SinkC.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkC(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkC.scala
+++ b/src/main/scala/devices/chiplink/SinkC.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Queue}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/devices/chiplink/SinkD.scala
+++ b/src/main/scala/devices/chiplink/SinkD.scala
@@ -27,7 +27,7 @@ class SinkD(info: ChipLinkInfo) extends Module
   val d_hasData = info.edgeOut.hasData(d.bits)
   val d_grant = d.bits.opcode === TLMessages.Grant || d.bits.opcode === TLMessages.GrantData
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := Mux(d_grant, s_sink, Mux(d_hasData, s_data, s_header)) }
       is (s_sink)     { state := Mux(d_hasData, s_data, s_header) }
@@ -37,9 +37,9 @@ class SinkD(info: ChipLinkInfo) extends Module
 
   // Release the TL source
   val relack = d.bits.opcode === TLMessages.ReleaseAck
-  io.a_tlSource.valid := io.q.fire() && state === s_header && !relack
+  io.a_tlSource.valid := io.q.fire && state === s_header && !relack
   io.a_tlSource.bits := d.bits.source
-  io.c_tlSource.valid := io.q.fire() && state === s_header &&  relack
+  io.c_tlSource.valid := io.q.fire && state === s_header &&  relack
   io.c_tlSource.bits := d.bits.source
 
   // Construct the header beat

--- a/src/main/scala/devices/chiplink/SinkD.scala
+++ b/src/main/scala/devices/chiplink/SinkD.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Queue, Valid}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/devices/chiplink/SinkD.scala
+++ b/src/main/scala/devices/chiplink/SinkD.scala
@@ -1,25 +1,26 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Queue, Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkD(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val d = Decoupled(new TLBundleD(info.edgeOut.bundle)).flip
+    val d = Flipped(Decoupled(new TLBundleD(info.edgeOut.bundle)))
     val q = Decoupled(new DataLayer(info.params))
-    val a_tlSource = Valid(UInt(width = info.params.sourceBits))
-    val a_clSource = UInt(INPUT, width = info.params.clSourceBits)
-    val c_tlSource = Valid(UInt(width = info.params.sourceBits))
-    val c_clSource = UInt(INPUT, width = info.params.clSourceBits)
+    val a_tlSource = Valid(UInt(info.params.sourceBits.W))
+    val a_clSource = Input(UInt(info.params.clSourceBits.W))
+    val c_tlSource = Valid(UInt(info.params.sourceBits.W))
+    val c_clSource = Input(UInt(info.params.clSourceBits.W))
   }
 
   // The FSM states
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_sink     = UInt(1, width = 2)
-  val s_data     = UInt(2, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_sink     = 1.U(2.W)
+  val s_data     = 2.U(2.W)
 
   // We need a Q because we stall the channel while serializing it's header
   val d = Queue(io.d, 1, flow=true)
@@ -44,7 +45,7 @@ class SinkD(info: ChipLinkInfo) extends Module
 
   // Construct the header beat
   val header = info.encode(
-    format = UInt(3),
+    format = 3.U,
     opcode = d.bits.opcode,
     param  = Cat(d.bits.denied, d.bits.param),
     size   = d.bits.size,
@@ -55,8 +56,8 @@ class SinkD(info: ChipLinkInfo) extends Module
   d.ready := io.q.ready && isLastState
   io.q.valid := d.valid
   io.q.bits.last  := d_last && isLastState
-  io.q.bits.data  := Vec(header, d.bits.sink, d.bits.data)(state)
-  io.q.bits.beats := Mux(d_hasData, info.size2beats(d.bits.size), UInt(0)) + UInt(1) + d_grant.asUInt
+  io.q.bits.data  := VecInit(header, d.bits.sink, d.bits.data)(state)
+  io.q.bits.beats := Mux(d_hasData, info.size2beats(d.bits.size), 0.U) + 1.U + d_grant.asUInt
 }
 
 /*

--- a/src/main/scala/devices/chiplink/SinkD.scala
+++ b/src/main/scala/devices/chiplink/SinkD.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkD(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkE.scala
+++ b/src/main/scala/devices/chiplink/SinkE.scala
@@ -14,7 +14,7 @@ class SinkE(info: ChipLinkInfo) extends Module
     val d_clSink = UInt(INPUT, width = info.params.clSinkBits)
   }
 
-  io.d_tlSink.valid := io.e.fire()
+  io.d_tlSink.valid := io.e.fire
   io.d_tlSink.bits := io.e.bits.sink
 
   val header = info.encode(

--- a/src/main/scala/devices/chiplink/SinkE.scala
+++ b/src/main/scala/devices/chiplink/SinkE.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkE(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkE.scala
+++ b/src/main/scala/devices/chiplink/SinkE.scala
@@ -1,35 +1,36 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkE(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val e = Decoupled(new TLBundleE(info.edgeIn.bundle)).flip
+    val e = Flipped(Decoupled(new TLBundleE(info.edgeIn.bundle)))
     val q = Decoupled(new DataLayer(info.params))
     // Find the sink from D
-    val d_tlSink = Valid(UInt(width = info.params.sinkBits))
-    val d_clSink = UInt(INPUT, width = info.params.clSinkBits)
+    val d_tlSink = Valid(UInt(info.params.sinkBits.W))
+    val d_clSink = Input(UInt(info.params.clSinkBits.W))
   }
 
   io.d_tlSink.valid := io.e.fire
   io.d_tlSink.bits := io.e.bits.sink
 
   val header = info.encode(
-    format = UInt(4),
-    opcode = UInt(0),
-    param  = UInt(0),
-    size   = UInt(0),
-    domain = UInt(0),
+    format = 4.U,
+    opcode = 0.U,
+    param  = 0.U,
+    size   = 0.U,
+    domain = 0.U,
     source = io.d_clSink)
 
   io.e.ready := io.q.ready
   io.q.valid := io.e.valid
-  io.q.bits.last  := Bool(true)
+  io.q.bits.last  := true.B
   io.q.bits.data  := header
-  io.q.bits.beats := UInt(1)
+  io.q.bits.beats := 1.U
 }
 
 /*

--- a/src/main/scala/devices/chiplink/SinkE.scala
+++ b/src/main/scala/devices/chiplink/SinkE.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Valid}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/devices/chiplink/SourceA.scala
+++ b/src/main/scala/devices/chiplink/SourceA.scala
@@ -42,9 +42,9 @@ class SourceA(info: ChipLinkInfo) extends Module
 
   val (_, q_last) = info.firstlast(io.q, Some(UInt(0)))
   val q_hasData = !q_opcode(2)
-  val a_first = RegEnable(state =/= s_data, io.q.fire())
+  val a_first = RegEnable(state =/= s_data, io.q.fire)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := s_address0 }
       is (s_address0) { state := s_address1 }

--- a/src/main/scala/devices/chiplink/SourceA.scala
+++ b/src/main/scala/devices/chiplink/SourceA.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, UIntToOH, Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -9,10 +10,10 @@ class SourceA(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
     val a = Decoupled(new TLBundleA(info.edgeOut.bundle))
-    val q = Decoupled(UInt(width = info.params.dataBits)).flip
+    val q = Flipped(Decoupled(UInt(width = info.params.dataBits)))
     // Used by D to find the txn
-    val d_tlSource = Valid(UInt(width = info.params.sourceBits)).flip
-    val d_clSource = UInt(OUTPUT, width = info.params.clSourceBits)
+    val d_tlSource = Flipped(Valid(UInt(width = info.params.sourceBits)))
+    val d_clSource = Output(UInt(info.params.clSourceBits.W))
   }
 
   // CAM of sources used for each domain
@@ -21,11 +22,11 @@ class SourceA(info: ChipLinkInfo) extends Module
   }
 
   // A simple FSM to generate the packet components
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_address0 = UInt(1, width = 2)
-  val s_address1 = UInt(2, width = 2)
-  val s_data     = UInt(3, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_address0 = 1.U(2.W)
+  val s_address1 = 2.U(2.W)
+  val s_data     = 3.U(2.W)
 
   private def hold(key: UInt)(data: UInt) = {
     val enable = state === key
@@ -40,7 +41,7 @@ class SourceA(info: ChipLinkInfo) extends Module
   val q_address0 = hold(s_address0)(io.q.bits)
   val q_address1 = hold(s_address1)(io.q.bits)
 
-  val (_, q_last) = info.firstlast(io.q, Some(UInt(0)))
+  val (_, q_last) = info.firstlast(io.q, Some(0.U))
   val q_hasData = !q_opcode(2)
   val a_first = RegEnable(state =/= s_data, io.q.fire)
 
@@ -66,8 +67,8 @@ class SourceA(info: ChipLinkInfo) extends Module
   val q_legal = exists && (!q_write || writeOk) && (!q_acq || acquireOk)
 
   // Look for an available source in the correct domain
-  val source_ok = Vec(cams.map(_.io.alloc.ready))(q_domain)
-  val source    = Vec(cams.map(_.io.key))(q_domain) holdUnless a_first
+  val source_ok = VecInit(cams.map(_.io.alloc.ready))(q_domain)
+  val source    = VecInit(cams.map(_.io.key))(q_domain) holdUnless a_first
   val a_sel = UIntToOH(q_domain)
 
   // Feed our preliminary A channel via the Partial Extractor FSM
@@ -83,7 +84,7 @@ class SourceA(info: ChipLinkInfo) extends Module
   a.bits.address := info.makeError(q_legal, q_address)
   a.bits.mask    := MaskGen(q_address0, q_size, info.params.dataBytes)
   a.bits.data    := io.q.bits
-  a.bits.corrupt := Bool(false)
+  a.bits.corrupt := false.B
 
   val stall = a_first && !source_ok
   val xmit = q_last || state === s_data
@@ -97,7 +98,7 @@ class SourceA(info: ChipLinkInfo) extends Module
   // Free the CAM entries
   val d_clDomain = io.d_tlSource.bits >> log2Ceil(info.params.sourcesPerDomain)
   val d_sel = UIntToOH(d_clDomain)
-  io.d_clSource := Vec(cams.map(_.io.data))(d_clDomain)
+  io.d_clSource := VecInit(cams.map(_.io.data))(d_clDomain)
   (cams zip d_sel.asBools) foreach { case (cam, sel) =>
     cam.io.free.bits  := io.d_tlSource.bits
     cam.io.free.valid := io.d_tlSource.valid && sel

--- a/src/main/scala/devices/chiplink/SourceA.scala
+++ b/src/main/scala/devices/chiplink/SourceA.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled, UIntToOH, Valid}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -10,9 +10,9 @@ class SourceA(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
     val a = Decoupled(new TLBundleA(info.edgeOut.bundle))
-    val q = Flipped(Decoupled(UInt(width = info.params.dataBits)))
+    val q = Flipped(Decoupled(UInt(width = info.params.dataBits.W)))
     // Used by D to find the txn
-    val d_tlSource = Flipped(Valid(UInt(width = info.params.sourceBits)))
+    val d_tlSource = Flipped(Valid(UInt(width = info.params.sourceBits.W)))
     val d_clSource = Output(UInt(info.params.clSourceBits.W))
   }
 
@@ -61,7 +61,7 @@ class SourceA(info: ChipLinkInfo) extends Module
   val exists = info.edgeOut.manager.containsSafe(q_address)
   private def writeable(m: TLManagerParameters): Boolean = if (m.supportsAcquireB) m.supportsAcquireT else m.supportsPutFull
   private def acquireable(m: TLManagerParameters): Boolean = m.supportsAcquireB || m.supportsAcquireT
-  private def toBool(x: Boolean) = Bool(x)
+  private def toBool(x: Boolean) = x.asBool
   val writeOk = info.edgeOut.manager.fastProperty(q_address, writeable, toBool)
   val acquireOk = info.edgeOut.manager.fastProperty(q_address, acquireable, toBool)
   val q_legal = exists && (!q_write || writeOk) && (!q_acq || acquireOk)

--- a/src/main/scala/devices/chiplink/SourceA.scala
+++ b/src/main/scala/devices/chiplink/SourceA.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceB.scala
+++ b/src/main/scala/devices/chiplink/SourceB.scala
@@ -37,9 +37,9 @@ class SourceB(info: ChipLinkInfo) extends Module
 
   val (_, q_last) = info.firstlast(io.q, Some(UInt(1)))
   val q_hasData = !q_opcode(2)
-  val b_first = RegEnable(state =/= s_data, io.q.fire())
+  val b_first = RegEnable(state =/= s_data, io.q.fire)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := s_address0 }
       is (s_address0) { state := s_address1 }

--- a/src/main/scala/devices/chiplink/SourceB.scala
+++ b/src/main/scala/devices/chiplink/SourceB.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -10,7 +10,7 @@ class SourceB(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
     val b = Decoupled(new TLBundleB(info.edgeIn.bundle))
-    val q = Flipped(Decoupled(UInt(width = info.params.dataBits)))
+    val q = Flipped(Decoupled(UInt(width = info.params.dataBits.W)))
   }
 
   // Find the optional cache (at most one)

--- a/src/main/scala/devices/chiplink/SourceB.scala
+++ b/src/main/scala/devices/chiplink/SourceB.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceC.scala
+++ b/src/main/scala/devices/chiplink/SourceC.scala
@@ -40,9 +40,9 @@ class SourceC(info: ChipLinkInfo) extends Module
 
   val (_, q_last) = info.firstlast(io.q, Some(UInt(2)))
   val q_hasData = q_opcode(0)
-  val c_first = RegEnable(state =/= s_data, io.q.fire())
+  val c_first = RegEnable(state =/= s_data, io.q.fire)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := s_address0 }
       is (s_address0) { state := s_address1 }

--- a/src/main/scala/devices/chiplink/SourceC.scala
+++ b/src/main/scala/devices/chiplink/SourceC.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Valid}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._

--- a/src/main/scala/devices/chiplink/SourceC.scala
+++ b/src/main/scala/devices/chiplink/SourceC.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -9,21 +10,21 @@ class SourceC(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
     val c = Decoupled(new TLBundleC(info.edgeOut.bundle))
-    val q = Decoupled(UInt(width = info.params.dataBits)).flip
+    val q = Flipped(Decoupled(UInt(info.params.dataBits.W)))
     // Used by D to find the txn
-    val d_tlSource = Valid(UInt(width = info.params.sourceBits)).flip
-    val d_clSource = UInt(OUTPUT, width = info.params.clSourceBits)
+    val d_tlSource = Flipped(Valid(UInt(info.params.sourceBits.W)))
+    val d_clSource = Output(UInt(info.params.clSourceBits.W))
   }
 
   // CAM of sources used for release
   val cam = Module(new CAM(info.params.sourcesPerDomain, info.params.clSourceBits))
 
   // A simple FSM to generate the packet components
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_address0 = UInt(1, width = 2)
-  val s_address1 = UInt(2, width = 2)
-  val s_data     = UInt(3, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_address0 = 1.U(2.W)
+  val s_address1 = 2.U(2.W)
+  val s_data     = 3.U(2.W)
 
   private def hold(key: UInt)(data: UInt) = {
     val enable = state === key
@@ -38,7 +39,7 @@ class SourceC(info: ChipLinkInfo) extends Module
   val q_address0 = hold(s_address0)(io.q.bits)
   val q_address1 = hold(s_address1)(io.q.bits)
 
-  val (_, q_last) = info.firstlast(io.q, Some(UInt(2)))
+  val (_, q_last) = info.firstlast(io.q, Some(2.U))
   val q_hasData = q_opcode(0)
   val c_first = RegEnable(state =/= s_data, io.q.fire)
 
@@ -56,7 +57,7 @@ class SourceC(info: ChipLinkInfo) extends Module
   val exists = info.edgeOut.manager.containsSafe(q_address)
   private def writeable(m: TLManagerParameters): Boolean = if (m.supportsAcquireB) m.supportsAcquireT else m.supportsPutFull
   private def acquireable(m: TLManagerParameters): Boolean = m.supportsAcquireB || m.supportsAcquireT
-  private def toBool(x: Boolean) = Bool(x)
+  private def toBool(x: Boolean) = x.B
   val writeOk = info.edgeOut.manager.fastProperty(q_address, writeable, toBool)
   val acquireOk = info.edgeOut.manager.fastProperty(q_address, acquireable, toBool)
   val q_legal = exists && (!q_hasData || writeOk) && acquireOk
@@ -69,10 +70,10 @@ class SourceC(info: ChipLinkInfo) extends Module
   io.c.bits.opcode  := q_opcode
   io.c.bits.param   := q_param
   io.c.bits.size    := q_size
-  io.c.bits.source  := Mux(q_release, source, UInt(0)) // always domain 0
+  io.c.bits.source  := Mux(q_release, source, 0.U) // always domain 0
   io.c.bits.address := info.makeError(q_legal, q_address)
   io.c.bits.data    := io.q.bits
-  io.c.bits.corrupt := Bool(false)
+  io.c.bits.corrupt := false.B
 
   val stall = c_first && !source_ok
   val xmit = q_last || state === s_data

--- a/src/main/scala/devices/chiplink/SourceC.scala
+++ b/src/main/scala/devices/chiplink/SourceC.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceD.scala
+++ b/src/main/scala/devices/chiplink/SourceD.scala
@@ -45,10 +45,10 @@ class SourceD(info: ChipLinkInfo) extends Module
 
   val q_grant = q_opcode === TLMessages.Grant || q_opcode === TLMessages.GrantData
   val (_, q_last) = info.firstlast(io.q, Some(UInt(3)))
-  val d_first = RegEnable(state =/= s_data, io.q.fire())
+  val d_first = RegEnable(state =/= s_data, io.q.fire)
   val s_maybe_data = Mux(q_last, s_header, s_data)
 
-  when (io.q.fire()) {
+  when (io.q.fire) {
     switch (state) {
       is (s_header)   { state := Mux(q_grant, s_sink, s_maybe_data) }
       is (s_sink)     { state := s_maybe_data }

--- a/src/main/scala/devices/chiplink/SourceD.scala
+++ b/src/main/scala/devices/chiplink/SourceD.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceD.scala
+++ b/src/main/scala/devices/chiplink/SourceD.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util.{Decoupled, Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -9,10 +10,10 @@ class SourceD(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
     val d = Decoupled(new TLBundleD(info.edgeIn.bundle))
-    val q = Decoupled(UInt(width = info.params.dataBits)).flip
+    val q = Flipped(Decoupled(UInt(info.params.dataBits.W)))
     // Used by E to find the txn
-    val e_tlSink = Valid(UInt(width = info.params.sinkBits)).flip
-    val e_clSink = UInt(OUTPUT, width = info.params.clSinkBits)
+    val e_tlSink = Flipped(Valid(UInt(info.params.sinkBits.W)))
+    val e_clSink = Output(UInt(info.params.clSinkBits.W))
   }
 
   // We need a sink id CAM
@@ -26,10 +27,10 @@ class SourceD(info: ChipLinkInfo) extends Module
   }
 
   // The FSM states
-  val state = RegInit(UInt(0, width = 2))
-  val s_header   = UInt(0, width = 2)
-  val s_sink     = UInt(1, width = 2)
-  val s_data     = UInt(2, width = 2)
+  val state = RegInit(0.U(2.W))
+  val s_header   = 0.U(2.W)
+  val s_sink     = 1.U(2.W)
+  val s_data     = 2.U(2.W)
 
   private def hold(key: UInt)(data: UInt) = {
     val enable = state === key
@@ -44,7 +45,7 @@ class SourceD(info: ChipLinkInfo) extends Module
   val q_sink = hold(s_sink)(io.q.bits(15, 0))
 
   val q_grant = q_opcode === TLMessages.Grant || q_opcode === TLMessages.GrantData
-  val (_, q_last) = info.firstlast(io.q, Some(UInt(3)))
+  val (_, q_last) = info.firstlast(io.q, Some(3.U))
   val d_first = RegEnable(state =/= s_data, io.q.fire)
   val s_maybe_data = Mux(q_last, s_header, s_data)
 
@@ -65,8 +66,8 @@ class SourceD(info: ChipLinkInfo) extends Module
   io.d.bits.opcode  := q_opcode
   io.d.bits.param   := q_param(1,0)
   io.d.bits.size    := q_size
-  io.d.bits.source  := Vec(muxes.map { m => m(q_source) })(q_domain)
-  io.d.bits.sink    := Mux(q_grant, sink, UInt(0))
+  io.d.bits.source  := VecInit(muxes.map { m => m(q_source) })(q_domain)
+  io.d.bits.sink    := Mux(q_grant, sink, 0.U)
   io.d.bits.denied  := q_param >> 2
   io.d.bits.data    := io.q.bits
   io.d.bits.corrupt := io.d.bits.denied && info.edgeIn.hasData(io.d.bits)

--- a/src/main/scala/devices/chiplink/SourceD.scala
+++ b/src/main/scala/devices/chiplink/SourceD.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._
-import chisel3.util.{Decoupled, Valid}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._

--- a/src/main/scala/devices/chiplink/SourceE.scala
+++ b/src/main/scala/devices/chiplink/SourceE.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{Decoupled}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._

--- a/src/main/scala/devices/chiplink/SourceE.scala
+++ b/src/main/scala/devices/chiplink/SourceE.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -9,7 +10,7 @@ class SourceE(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
     val e = Decoupled(new TLBundleE(info.edgeOut.bundle))
-    val q = Decoupled(UInt(width = info.params.dataBits)).flip
+    val q = Flipped(Decoupled(UInt(info.params.dataBits.W)))
   }
 
   // Extract header fields

--- a/src/main/scala/devices/chiplink/SourceE.scala
+++ b/src/main/scala/devices/chiplink/SourceE.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/StuckSnooper.scala
+++ b/src/main/scala/devices/chiplink/StuckSnooper.scala
@@ -59,7 +59,7 @@ class StuckSnooper(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(i
 
     //Enable probes to in1 only after it issues an acquire
     val divertprobes = RegInit(true.B)
-    divertprobes := divertprobes && ~(in1.a.fire() && (in1.a.bits.opcode === TLMessages.AcquireBlock || in1.a.bits.opcode === TLMessages.AcquirePerm))
+    divertprobes := divertprobes && ~(in1.a.fire && (in1.a.bits.opcode === TLMessages.AcquireBlock || in1.a.bits.opcode === TLMessages.AcquirePerm))
     val bypass_c = Wire(Bool()) 
     bypass_c := bypass || divertprobes
 

--- a/src/main/scala/devices/chiplink/StuckSnooper.scala
+++ b/src/main/scala/devices/chiplink/StuckSnooper.scala
@@ -30,7 +30,7 @@ class StuckSnooper(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(i
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
       val bypass = Input(Bool())
-      val pending = Input(Bool())
+      val pending = Output(Bool())
     })
 
     val Seq((in0, edgeIn0), (in1, edgeIn1)) = node.in

--- a/src/main/scala/devices/chiplink/StuckSnooper.scala
+++ b/src/main/scala/devices/chiplink/StuckSnooper.scala
@@ -3,7 +3,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._
 import chisel3.util.random.LFSR
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/chiplink/StuckSnooper.scala
+++ b/src/main/scala/devices/chiplink/StuckSnooper.scala
@@ -1,7 +1,8 @@
 
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util.random.LFSR
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
@@ -29,8 +30,8 @@ class StuckSnooper(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(i
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val bypass = Bool(INPUT)
-      val pending = Bool(OUTPUT)
+      val bypass = Input(Bool())
+      val pending = Input(Bool())
     })
 
     val Seq((in0, edgeIn0), (in1, edgeIn1)) = node.in
@@ -42,13 +43,13 @@ class StuckSnooper(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(i
     val (flight, next_flight) = edgeOut.inFlight(out)
 
     io.pending := (flight > 0.U)
-    when (next_flight === UInt(0)) { bypass := io.bypass }
+    when (next_flight === 0.U) { bypass := io.bypass }
     val stall = (bypass =/= io.bypass) && edgeOut.first(out.a)
 
     in0.a.ready := !stall && out.a.ready &&  bypass
     in1.a.ready := !stall && out.a.ready && !bypass
     out.a.valid := !stall && Mux(bypass, in0.a.valid, in1.a.valid)
-    def castA(x: TLBundleA) = { val ret = Wire(out.a.bits); ret <> x; ret }
+    def castA(x: TLBundleA) = { val ret = WireDefault(out.a.bits); ret <> x; ret }
     out.a.bits := Mux(bypass, castA(in0.a.bits), castA(in1.a.bits))
 
     out.d.ready := Mux(bypass, in0.d.ready, in1.d.ready)
@@ -73,26 +74,26 @@ class StuckSnooper(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(i
       in0.c.ready := out.c.ready &&  bypass_c
       in1.c.ready := out.c.ready && !bypass_c
       out.c.valid := Mux(bypass_c, in0.c.valid, in1.c.valid)
-      def castC(x: TLBundleC) = { val ret = Wire(out.c.bits); ret <> x; ret }
+      def castC(x: TLBundleC) = { val ret = WireDefault(out.c.bits); ret <> x; ret }
       out.c.bits := Mux(bypass_c, castC(in0.c.bits), castC(in1.c.bits))
 
       in0.e.ready := out.e.ready &&  bypass_c
       in1.e.ready := out.e.ready && !bypass_c
       out.e.valid := Mux(bypass_c, in0.e.valid, in1.e.valid)
-      def castE(x: TLBundleE) = { val ret = Wire(out.e.bits); ret <> x; ret }
+      def castE(x: TLBundleE) = { val ret = WireDefault(out.e.bits); ret <> x; ret }
       out.e.bits := Mux(bypass_c, castE(in0.e.bits), castE(in1.e.bits))
     } else {
-      in0.b.valid := Bool(false)
-      in0.c.ready := Bool(true)
-      in0.e.ready := Bool(true)
+      in0.b.valid := false.B
+      in0.c.ready := true.B
+      in0.e.ready := true.B
 
-      in1.b.valid := Bool(false)
-      in1.c.ready := Bool(true)
-      in1.e.ready := Bool(true)
+      in1.b.valid := false.B
+      in1.c.ready := true.B
+      in1.e.ready := true.B
 
-      out.b.ready := Bool(true)
-      out.c.valid := Bool(false)
-      out.e.valid := Bool(false)
+      out.b.ready := true.B
+      out.c.valid := false.B
+      out.e.valid := false.B
     }
   }
 }
@@ -114,7 +115,7 @@ class TLStuckSnooperTester(txns: Int)(implicit p: Parameters) extends LazyModule
 
   lazy val module = new LazyModuleImp(this) with UnitTestModule {
     io.finished := fuzz1.module.io.finished && fuzz2.module.io.finished
-    mux.module.io.bypass := LFSR64(Bool(true))(0)
+    mux.module.io.bypass := LFSR(64, true.B)(0)
   }
 }
 

--- a/src/main/scala/devices/chiplink/TX.scala
+++ b/src/main/scala/devices/chiplink/TX.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.chiplink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{DecoupledIO, log2Ceil, Mux1H}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -8,22 +9,22 @@ import freechips.rocketchip.util._
 class TX(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
-    val c2b_clk  = Clock(OUTPUT)
-    val c2b_rst  = Bool(OUTPUT)
-    val c2b_send = Bool(OUTPUT)
-    val c2b_data = UInt(OUTPUT, info.params.dataBits)
-    val a = new AsyncBundle(new DataLayer(info.params), info.params.crossing).flip
-    val b = new AsyncBundle(new DataLayer(info.params), info.params.crossing).flip
-    val c = new AsyncBundle(new DataLayer(info.params), info.params.crossing).flip
-    val d = new AsyncBundle(new DataLayer(info.params), info.params.crossing).flip
-    val e = new AsyncBundle(new DataLayer(info.params), info.params.crossing).flip
-    val sa = DecoupledIO(new DataLayer(info.params)).flip
-    val sb = DecoupledIO(new DataLayer(info.params)).flip
-    val sc = DecoupledIO(new DataLayer(info.params)).flip
-    val sd = DecoupledIO(new DataLayer(info.params)).flip
-    val se = DecoupledIO(new DataLayer(info.params)).flip
-    val rxc = new AsyncBundle(new CreditBump(info.params), AsyncQueueParams.singleton()).flip
-    val txc = new AsyncBundle(new CreditBump(info.params), AsyncQueueParams.singleton()).flip
+    val c2b_clk  = Output(Clock())
+    val c2b_rst  = Output(Bool())
+    val c2b_send = Output(Bool())
+    val c2b_data = Output(UInt(info.params.dataBits.W))
+    val a = Flipped(new AsyncBundle(new DataLayer(info.params), info.params.crossing))
+    val b = Flipped(new AsyncBundle(new DataLayer(info.params), info.params.crossing))
+    val c = Flipped(new AsyncBundle(new DataLayer(info.params), info.params.crossing))
+    val d = Flipped(new AsyncBundle(new DataLayer(info.params), info.params.crossing))
+    val e = Flipped(new AsyncBundle(new DataLayer(info.params), info.params.crossing))
+    val sa = Flipped(DecoupledIO(new DataLayer(info.params)))
+    val sb = Flipped(DecoupledIO(new DataLayer(info.params)))
+    val sc = Flipped(DecoupledIO(new DataLayer(info.params)))
+    val sd = Flipped(DecoupledIO(new DataLayer(info.params)))
+    val se = Flipped(DecoupledIO(new DataLayer(info.params)))
+    val rxc = Flipped(new AsyncBundle(new CreditBump(info.params), AsyncQueueParams.singleton()))
+    val txc = Flipped(new AsyncBundle(new CreditBump(info.params), AsyncQueueParams.singleton()))
   }
 
   // Currently available credits
@@ -33,8 +34,8 @@ class TX(info: ChipLinkInfo) extends Module
   // Constantly pull credits from RX
   val rxInc = FromAsyncBundle(io.rxc)
   val txInc = FromAsyncBundle(io.txc)
-  rxInc.ready := Bool(true)
-  txInc.ready := Bool(true)
+  rxInc.ready := true.B
+  txInc.ready := true.B
 
   // Cross the requests (if necessary)
   val sync = info.params.syncTX
@@ -47,10 +48,10 @@ class TX(info: ChipLinkInfo) extends Module
 
   // Consume TX credits and propagate pre-paid requests
   val ioX = (qX zip (tx.X zip txInc.bits.X)) map { case (q, (credit, gain)) =>
-    val first = RegEnable(q.bits.last, Bool(true), q.fire)
+    val first = RegEnable(q.bits.last, true.B, q.fire)
     val delta = credit -& q.bits.beats
-    val allow = !first || (delta.asSInt >= SInt(0))
-    credit := Mux(q.fire && first, delta, credit) + Mux(txInc.fire, gain, UInt(0))
+    val allow = !first || (delta.asSInt >= 0.S)
+    credit := Mux(q.fire && first, delta, credit) + Mux(txInc.fire, gain, 0.U)
 
     val cq = Module(new ShiftQueue(q.bits.cloneType, 2)) // maybe flow?
     cq.io.enq.bits := q.bits
@@ -62,24 +63,24 @@ class TX(info: ChipLinkInfo) extends Module
   // Prepare RX credit update headers
   val rxQ = Module(new ShiftQueue(new DataLayer(info.params), 2)) // maybe flow?
   val (rxHeader, rxLeft) = rx.toHeader
-  rxQ.io.enq.valid := Bool(true)
+  rxQ.io.enq.valid := true.B 
   rxQ.io.enq.bits.data  := rxHeader
-  rxQ.io.enq.bits.last  := Bool(true)
-  rxQ.io.enq.bits.beats := UInt(1)
+  rxQ.io.enq.bits.last  := true.B 
+  rxQ.io.enq.bits.beats := 1.U
   rx := Mux(rxQ.io.enq.fire, rxLeft, rx) + Mux(rxInc.fire, rxInc.bits, CreditBump(info.params, 0))
 
   // Include the F credit channel in arbitration
-  val f = Wire(rxQ.io.deq)
+  val f = WireDefault(rxQ.io.deq)
   val ioF = ioX :+ f
   val requests = Cat(ioF.map(_.valid).reverse)
   val lasts = Cat(ioF.map(_.bits.last).reverse)
 
   // How often should we force transmission of a credit update? sqrt
   val xmitBits = log2Ceil(info.params.Qdepth) / 2
-  val xmit = RegInit(UInt(0, width = xmitBits))
-  val forceXmit = xmit === UInt(0)
-  when (!forceXmit) { xmit := xmit - UInt(1) }
-  when (f.fire) { xmit := ~UInt(0, width = xmitBits) }
+  val xmit = RegInit(0.U(xmitBits.W))
+  val forceXmit = xmit === 0.U
+  when (!forceXmit) { xmit := xmit - 1.U }
+  when (f.fire) { xmit := ~0.U(xmitBits.W) }
 
   // Flow control for returned credits
   val allowReturn = !ioX.map(_.valid).reduce(_ || _) || forceXmit
@@ -88,25 +89,25 @@ class TX(info: ChipLinkInfo) extends Module
   rxQ.io.deq.ready := f.ready && allowReturn
 
   // Select a channel to transmit from those with data and space
-  val first = RegInit(Bool(true))
-  val state = Reg(UInt(0, width=6))
+  val first = RegInit(true.B)
+  val state = RegInit(0.U(6.W))
   val readys = TLArbiter.roundRobin(6, requests, first)
   val winner = readys & requests
   val grant = Mux(first, winner, state)
   val allowed = Mux(first, readys, state)
   (ioF zip allowed.asBools) foreach { case (beat, sel) => beat.ready := sel }
 
-  val send = Mux(first, rxQ.io.deq.valid, (state & requests) =/= UInt(0))
-  assert (send === ((grant & requests) =/= UInt(0)))
+  val send = Mux(first, rxQ.io.deq.valid, (state & requests) =/= 0.U)
+  assert (send === ((grant & requests) =/= 0.U))
 
   when (send) { first := (grant & lasts).orR }
   when (first) { state := winner }
 
   // Form the output beat
   io.c2b_clk  := clock
-  io.c2b_rst  := AsyncResetReg(Bool(false), clock, reset, true, None)
-  io.c2b_send := RegNext(RegNext(send, Bool(false)), Bool(false))
-  io.c2b_data := RegNext(Mux1H(RegNext(grant), RegNext(Vec(ioF.map(_.bits.data)))))
+  io.c2b_rst  := AsyncResetReg(false.B, clock, reset, true, None)
+  io.c2b_send := RegNext(RegNext(send, false.B), false.B)
+  io.c2b_data := RegNext(Mux1H(RegNext(grant), RegNext(VecInit(ioF.map(_.bits.data)))))
 }
 
 /*

--- a/src/main/scala/devices/chiplink/TX.scala
+++ b/src/main/scala/devices/chiplink/TX.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.chiplink
 
 import chisel3._ 
-import chisel3.util.{DecoupledIO, log2Ceil, Mux1H}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -105,7 +105,7 @@ class TX(info: ChipLinkInfo) extends Module
 
   // Form the output beat
   io.c2b_clk  := clock
-  io.c2b_rst  := AsyncResetReg(false.B, clock, reset, true, None)
+  io.c2b_rst  := AsyncResetReg(false.B, clock, reset.asBool, true, None)
   io.c2b_send := RegNext(RegNext(send, false.B), false.B)
   io.c2b_data := RegNext(Mux1H(RegNext(grant), RegNext(VecInit(ioF.map(_.bits.data)))))
 }

--- a/src/main/scala/devices/chiplink/TX.scala
+++ b/src/main/scala/devices/chiplink/TX.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.chiplink
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.gpio
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -72,18 +72,18 @@ abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
   // -------------------------------------------------
 
   // SW Control only.
-  val portReg = RegInit(0.U(c.width))
+  val portReg = RegInit(0.U(c.width.W))
 
   val oeReg  = Module(new AsyncResetRegVec(c.width, 0))
   val pueReg = Module(new AsyncResetRegVec(c.width, 0))
-  val dsReg  = RegInit(VecInit(Seq.fill(c.dsWidth)(0.U(c.width))))
+  val dsReg  = RegInit(VecInit(Seq.fill(c.dsWidth)(0.U(c.width.W))))
   val ieReg  = Module(new AsyncResetRegVec(c.width, 0))
-  val psReg  = RegInit(0.U(c.width))
+  val psReg  = RegInit(0.U(c.width.W))
   val poeReg = Module(new AsyncResetRegVec(c.width, 0))
 
   // Synchronize Input to get valueReg
   val inVal = WireDefault(0.U(c.width.W))
-  inVal := Vec(port.pins.map(_.i.ival)).asUInt
+  inVal := port.pins.map(_.i.ival).asUInt
   val inSyncReg  = SynchronizerShiftReg(inVal, 3, Some("inSyncReg"))
   val valueReg   = RegNext(inSyncReg, 0.U(c.width.W))
 

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.gpio
 
-import Chisel.{defaultCompileOptions => _, _}
-import chisel3.{VecInit}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
@@ -32,8 +31,8 @@ class GPIOPortIO(val c: GPIOParams) extends Bundle {
 }
 
 class IOFPortIO(val w: Int) extends Bundle {
-  val iof_0 = Vec(w, new IOFPin).flip
-  val iof_1 = Vec(w, new IOFPin).flip
+  val iof_0 = Flipped(Vec(w, new IOFPin))
+  val iof_1 = Flipped(Vec(w, new IOFPin))
 }
 
 case class GPIOParams(
@@ -73,39 +72,39 @@ abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
   // -------------------------------------------------
 
   // SW Control only.
-  val portReg = Reg(init = UInt(0, c.width))
+  val portReg = RegInit(0.U(c.width))
 
   val oeReg  = Module(new AsyncResetRegVec(c.width, 0))
   val pueReg = Module(new AsyncResetRegVec(c.width, 0))
-  val dsReg  = RegInit(VecInit(Seq.fill(c.dsWidth)(UInt(0, c.width))))
+  val dsReg  = RegInit(VecInit(Seq.fill(c.dsWidth)(0.U(c.width))))
   val ieReg  = Module(new AsyncResetRegVec(c.width, 0))
-  val psReg  = Reg(init = UInt(0, c.width))
+  val psReg  = RegInit(0.U(c.width))
   val poeReg = Module(new AsyncResetRegVec(c.width, 0))
 
   // Synchronize Input to get valueReg
-  val inVal = Wire(UInt(0, width=c.width))
+  val inVal = WireDefault(0.U(c.width.W))
   inVal := Vec(port.pins.map(_.i.ival)).asUInt
   val inSyncReg  = SynchronizerShiftReg(inVal, 3, Some("inSyncReg"))
-  val valueReg   = Reg(init = UInt(0, c.width), next = inSyncReg)
+  val valueReg   = RegNext(inSyncReg, 0.U(c.width.W))
 
   // Interrupt Configuration
-  val highIeReg = Reg(init = UInt(0, c.width))
-  val lowIeReg  = Reg(init = UInt(0, c.width))
-  val riseIeReg = Reg(init = UInt(0, c.width))
-  val fallIeReg = Reg(init = UInt(0, c.width))
-  val highIpReg = Reg(init = UInt(0, c.width))
-  val lowIpReg  = Reg(init = UInt(0, c.width))
-  val riseIpReg = Reg(init = UInt(0, c.width))
-  val fallIpReg = Reg(init = UInt(0, c.width))
-  val passthruHighIeReg = Reg(init = UInt(0, c.width))
-  val passthruLowIeReg  = Reg(init = UInt(0, c.width))
+  val highIeReg = RegInit(0.U(c.width.W))
+  val lowIeReg  = RegInit(0.U(c.width.W))
+  val riseIeReg = RegInit(0.U(c.width.W))
+  val fallIeReg = RegInit(0.U(c.width.W))
+  val highIpReg = RegInit(0.U(c.width.W))
+  val lowIpReg  = RegInit(0.U(c.width.W))
+  val riseIpReg = RegInit(0.U(c.width.W))
+  val fallIpReg = RegInit(0.U(c.width.W))
+  val passthruHighIeReg = RegInit(0.U(c.width.W))
+  val passthruLowIeReg  = RegInit(0.U(c.width.W))
 
   // HW IO Function
   val iofEnReg  = Module(new AsyncResetRegVec(c.width, 0))
-  val iofSelReg = Reg(init = UInt(0, c.width))
+  val iofSelReg = RegInit(0.U(c.width.W))
   
   // Invert Output
-  val xorReg    = Reg(init = UInt(0, c.width))
+  val xorReg    = RegInit(0.U(c.width.W))
 
   //--------------------------------------------------
   // CSR Access Logic (most of this section is boilerplate)

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.gpio
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import sifive.blocks.devices.pinctrl.{Pin}
 
 // While this is a bit pendantic, it keeps the GPIO

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -1,8 +1,7 @@
 package sifive.blocks.devices.gpio
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import chisel3.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{Pin}
 
 // While this is a bit pendantic, it keeps the GPIO

--- a/src/main/scala/devices/gpio/IOF.scala
+++ b/src/main/scala/devices/gpio/IOF.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.gpio
 
 import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
 
@@ -27,7 +28,7 @@ object IOFCtrl {
 // Package up the inputs and outputs
 // for the IOF
 class IOFPin extends Pin {
-  val o  = new IOFCtrl().asOutput
+  val o  = Output(IOFCtrl())
 
   def default(): Unit = {
     this.o.oval  := false.B

--- a/src/main/scala/devices/gpio/IOF.scala
+++ b/src/main/scala/devices/gpio/IOF.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.gpio
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
 
 // This is the actual IOF interface.pa

--- a/src/main/scala/devices/gpio/IOF.scala
+++ b/src/main/scala/devices/gpio/IOF.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.gpio
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
 
@@ -16,10 +16,10 @@ class IOFCtrl extends PinCtrl {
 object IOFCtrl {
   def apply(): IOFCtrl = {
     val iof = Wire(new IOFCtrl())
-    iof.valid := Bool(false)
-    iof.oval  := Bool(false)
-    iof.oe    := Bool(false)
-    iof.ie    := Bool(false)
+    iof.valid := false.B
+    iof.oval  := false.B
+    iof.oe    := false.B
+    iof.ie    := false.B
     iof
   }
 }
@@ -30,25 +30,25 @@ class IOFPin extends Pin {
   val o  = new IOFCtrl().asOutput
 
   def default(): Unit = {
-    this.o.oval  := Bool(false)
-    this.o.oe    := Bool(false)
-    this.o.ie    := Bool(false)
-    this.o.valid := Bool(false)
+    this.o.oval  := false.B
+    this.o.oe    := false.B
+    this.o.ie    := false.B
+    this.o.valid := false.B
   }
 
-  def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
-    this.o.oval := Bool(false)
-    this.o.oe   := Bool(false)
-    this.o.ie   := Bool(true)
+  def inputPin(pue: Bool = false.B /*ignored*/): Bool = {
+    this.o.oval := false.B
+    this.o.oe   := false.B
+    this.o.ie   := true.B
     this.i.ival
   }
   def outputPin(signal: Bool,
-    pue: Bool = Bool(false), /*ignored*/
-    ds: Bool = Bool(false), /*ignored*/
-    ie: Bool = Bool(false)
+    pue: Bool = false.B, /*ignored*/
+    ds: Bool = false.B, /*ignored*/
+    ie: Bool = false.B
   ): Unit = {
     this.o.oval := signal
-    this.o.oe   := Bool(true)
+    this.o.oe   := true.B
     this.o.ie   := ie
   }
 }
@@ -58,7 +58,7 @@ class IOFPin extends Pin {
 object BasePinToIOF {
   def apply(pin: BasePin, iof: IOFPin): Unit = {
     iof <> pin
-    iof.o.valid := Bool(true)
+    iof.o.valid := true.B
   }
 }
 

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -43,7 +43,6 @@ package sifive.blocks.devices.i2c
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -42,7 +42,7 @@
 package sifive.blocks.devices.i2c
 
 import chisel3._
-import chisel3.util.Enum
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
@@ -534,7 +534,7 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
   status.irqFlag            := (cmdAck || arbLost || status.irqFlag) && !cmd.irqAck // interrupt request flag is always generated
 
 
-  val statusReadReady = Reg(init = true.B)
+  val statusReadReady = RegInit(true.B)
   when (cmdAck || arbLost) {    // => cmd.read or cmd.write deassert 1 cycle later => transferInProgress deassert 2 cycles later
     statusReadReady := false.B  // do not allow status read if status.transferInProgress is going to change
   }

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -41,7 +41,8 @@
 
 package sifive.blocks.devices.i2c
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util.Enum
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
@@ -61,9 +62,9 @@ case class I2CParams(
   intXType: ClockCrossingType = NoCrossing) extends DeviceParams
 
 class I2CPin extends Bundle {
-  val in  = Bool(INPUT)
-  val out = Bool(OUTPUT)
-  val oe  = Bool(OUTPUT)
+  val in  = Input(Bool())
+  val out = Output(Bool())
+  val oe  = Output(Bool())
 }
 
 class I2CPort extends Bundle {
@@ -85,11 +86,11 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
 
   lazy val module = new LazyModuleImp(this) {
 
-  val I2C_CMD_NOP   = UInt(0x00)
-  val I2C_CMD_START = UInt(0x01)
-  val I2C_CMD_STOP  = UInt(0x02)
-  val I2C_CMD_WRITE = UInt(0x04)
-  val I2C_CMD_READ  = UInt(0x08)
+  val I2C_CMD_NOP   = 0x00.U
+  val I2C_CMD_START = 0x01.U
+  val I2C_CMD_STOP  = 0x02.U
+  val I2C_CMD_WRITE = 0x04.U
+  val I2C_CMD_READ  = 0x08.U
 
   class PrescalerBundle extends Bundle{
     val hi = UInt(8.W)
@@ -122,12 +123,12 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
   }
 
   // control state visible to SW/driver
-  val prescaler    = Reg(init = (new PrescalerBundle).fromBits(0xFFFF.U))
-  val control      = Reg(init = (new ControlBundle).fromBits(0.U))
-  val transmitData = Reg(init = UInt(0, 8.W))
-  val receivedData = Reg(init = UInt(0, 8.W))
-  val cmd          = Reg(init = (new CommandBundle).fromBits(0.U))
-  val status       = Reg(init = (new StatusBundle).fromBits(0.U))
+  val prescaler    = RegInit(0xFFFF.U.asTypeOf(new PrescalerBundle())) 
+  val control      = RegInit(0.U.asTypeOf(new ControlBundle())) 
+  val transmitData = RegInit(0.U(8.W))
+  val receivedData = RegInit(0.U(8.W))
+  val cmd          = RegInit(0.U.asTypeOf(new CommandBundle())) 
+  val status       = RegInit(0.U.asTypeOf(new StatusBundle())) 
 
 
   //////// Bit level ////////
@@ -136,7 +137,7 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
   port.sda.out := false.B                           // i2c data line output
 
   // filter SCL and SDA signals; (attempt to) remove glitches
-  val filterCnt = Reg(init = UInt(0, 14.W))
+  val filterCnt = RegInit(0.U(14.W))
   when ( !control.coreEn ) {
     filterCnt := 0.U
   } .elsewhen (!(filterCnt.orR)) {
@@ -145,25 +146,25 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
     filterCnt := filterCnt - 1.U
   }
 
-  val fSCL      = Reg(init = UInt(0x7, 3.W))
-  val fSDA      = Reg(init = UInt(0x7, 3.W))
+  val fSCL      = RegInit(0x7.U(3.W))
+  val fSDA      = RegInit(0x7.U(3.W))
   when (!(filterCnt.orR)) {
     fSCL := Cat(fSCL, port.scl.in)
     fSDA := Cat(fSDA, port.sda.in)
   }
 
-  val sSCL      = Reg(init = true.B, next = Majority(fSCL))
-  val sSDA      = Reg(init = true.B, next = Majority(fSDA))
+  val sSCL      = RegNext(Majority(fSCL), true.B)
+  val sSDA      = RegNext(Majority(fSDA), true.B)
 
-  val dSCL      = Reg(init = true.B, next = sSCL)
-  val dSDA      = Reg(init = true.B, next = sSDA)
+  val dSCL      = RegNext(sSCL, true.B)
+  val dSDA      = RegNext(sSDA, true.B)
 
-  val dSCLOen   = Reg(next = port.scl.oe) // delayed scl_oen
+  val dSCLOen   = RegNext(port.scl.oe) // delayed scl_oen
 
   // detect start condition => detect falling edge on SDA while SCL is high
   // detect stop  condition => detect rising  edge on SDA while SCL is high
-  val startCond = Reg(init = false.B, next = !sSDA &&  dSDA && sSCL)
-  val stopCond  = Reg(init = false.B, next =  sSDA && !dSDA && sSCL)
+  val startCond = RegNext(!sSDA &&  dSDA && sSCL, false.B)
+  val stopCond  = RegNext(sSDA && !dSDA && sSCL, false.B)
 
   // master drives SCL high, but another master pulls it low
   // master start counting down its low cycle now (clock synchronization)
@@ -171,11 +172,11 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
 
   // slave_wait is asserted when master wants to drive SCL high, but the slave pulls it low
   // slave_wait remains asserted until the slave releases SCL
-  val slaveWait = Reg(init = false.B)
+  val slaveWait = RegInit(false.B)
   slaveWait := (port.scl.oe && !dSCLOen && !sSCL) || (slaveWait && !sSCL)
 
-  val clkEn     = Reg(init = true.B)     // clock generation signals
-  val cnt       = Reg(init = UInt(0, 16.W))  // clock divider counter (synthesis)
+  val clkEn     = RegInit(true.B)     // clock generation signals
+  val cnt       = RegInit(0.U(16.W))  // clock divider counter (synthesis)
 
   // generate clk enable signal
   when (!(cnt.orR) || !control.coreEn || sclSync ) {
@@ -190,35 +191,35 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
     clkEn := false.B
   }
 
-  val sclOen     = Reg(init = true.B)
+  val sclOen     = RegInit(true.B)
   port.scl.oe := !sclOen
 
-  val sdaOen     = Reg(init = true.B)
+  val sdaOen     = RegInit(true.B)
   port.sda.oe := !sdaOen
 
-  val sdaChk     = Reg(init = false.B)       // check SDA output (Multi-master arbitration)
+  val sdaChk     = RegInit(false.B)       // check SDA output (Multi-master arbitration)
 
-  val transmitBit = Reg(init = false.B)
+  val transmitBit = RegInit(false.B)
   val receivedBit = Reg(Bool())
   when (sSCL && !dSCL) {
     receivedBit := sSDA
   }
 
-  val bitCmd      = Reg(init = UInt(0, 4.W)) // command (from byte controller)
-  val bitCmdStop  = Reg(init = false.B)
+  val bitCmd      = RegInit(0.U(4.W)) // command (from byte controller)
+  val bitCmdStop  = RegInit(false.B)
   when (clkEn) {
     bitCmdStop := bitCmd === I2C_CMD_STOP
   }
-  val bitCmdAck   = Reg(init = false.B)
+  val bitCmdAck   = RegInit(false.B)
 
   val (s_bit_idle ::
        s_bit_start_a :: s_bit_start_b :: s_bit_start_c :: s_bit_start_d :: s_bit_start_e ::
        s_bit_stop_a  :: s_bit_stop_b  :: s_bit_stop_c  :: s_bit_stop_d  ::
        s_bit_rd_a    :: s_bit_rd_b    :: s_bit_rd_c    :: s_bit_rd_d    ::
-       s_bit_wr_a    :: s_bit_wr_b    :: s_bit_wr_c    :: s_bit_wr_d    :: Nil) = Enum(UInt(), 18)
-  val bitState    = Reg(init = s_bit_idle)
+       s_bit_wr_a    :: s_bit_wr_b    :: s_bit_wr_c    :: s_bit_wr_d    :: Nil) = Enum(18)
+  val bitState    = RegInit(s_bit_idle)
 
-  val arbLost     = Reg(init = false.B, next = (sdaChk && !sSDA && sdaOen) | ((bitState =/= s_bit_idle) && stopCond && !bitCmdStop))
+  val arbLost     = RegNext((sdaChk && !sSDA && sdaOen) | ((bitState =/= s_bit_idle) && stopCond && !bitCmdStop), false.B)
 
   // bit FSM
   when (arbLost) {
@@ -358,13 +359,13 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
 
 
   //////// Byte level ///////
-  val load        = Reg(init = false.B)                         // load shift register
-  val shift       = Reg(init = false.B)                         // shift shift register
-  val cmdAck      = Reg(init = false.B)                         // also done
-  val receivedAck = Reg(init = false.B)                         // from I2C slave
+  val load        = RegInit(false.B)                         // load shift register
+  val shift       = RegInit(false.B)                         // shift shift register
+  val cmdAck      = RegInit(false.B)                         // also done
+  val receivedAck = RegInit(false.B)                         // from I2C slave
   val go          = (cmd.read | cmd.write | cmd.stop) & !cmdAck
 
-  val bitCnt      = Reg(init = UInt(0, 3.W))
+  val bitCnt      = RegInit(0.U(3.W))
   when (load) {
     bitCnt := 0x7.U
   }
@@ -381,8 +382,8 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
     receivedData := Cat(receivedData, receivedBit)
   }
 
-  val (s_byte_idle :: s_byte_start :: s_byte_read :: s_byte_write :: s_byte_ack :: s_byte_stop :: Nil) = Enum(UInt(), 6)
-  val byteState   = Reg(init = s_byte_idle)
+  val (s_byte_idle :: s_byte_start :: s_byte_read :: s_byte_write :: s_byte_ack :: s_byte_stop :: Nil) = Enum(6)
+  val byteState   = RegInit(s_byte_idle)
 
   when (arbLost) {
     bitCmd      := I2C_CMD_NOP
@@ -504,7 +505,7 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
 
   // hack: b/c the same register offset is used to write cmd and read status
   val nextCmd = Wire(UInt(8.W))
-  cmd := (new CommandBundle).fromBits(nextCmd)
+  cmd := nextCmd.asTypeOf(new CommandBundle)
   nextCmd := cmd.asUInt & 0xFE.U  // clear IRQ_ACK bit (essentially 1 cycle pulse b/c it is overwritten by regmap below)
 
   // Note: This wins over the regmap update of nextCmd (even if something tries to write them to 1, these values take priority).

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.i2c
 
 import chisel3._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem}

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.i2c
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.i2c
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{withClockAndReset}
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
@@ -19,12 +19,12 @@ object I2CPinsFromPort {
     withClockAndReset(clock, reset) {
       pins.scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
       pins.scl.o.oe := i2c.scl.oe
-      i2c.scl.in := SyncResetSynchronizerShiftReg(pins.scl.i.ival, syncStages, init = Bool(true),
+      i2c.scl.in := SyncResetSynchronizerShiftReg(pins.scl.i.ival, syncStages, init = true.B,
         name = Some("i2c_scl_sync"))
 
       pins.sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
       pins.sda.o.oe := i2c.sda.oe
-      i2c.sda.in := SyncResetSynchronizerShiftReg(pins.sda.i.ival, syncStages, init = Bool(true),
+      i2c.sda.in := SyncResetSynchronizerShiftReg(pins.sda.i.ival, syncStages, init = true.B,
         name = Some("i2c_sda_sync"))
     }
   }

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.i2c
 
 import chisel3._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{withClockAndReset}
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
 import sifive.blocks.devices.pinctrl.{Pin, PinCtrl}

--- a/src/main/scala/devices/jtag/JTAGPins.scala
+++ b/src/main/scala/devices/jtag/JTAGPins.scala
@@ -25,10 +25,10 @@ class JTAGPins[T <: Pin](pingen: () => T, hasTRSTn: Boolean = true) extends JTAG
 object JTAGPinsFromPort {
 
   def apply[T <: Pin] (pins: JTAGSignals[T], jtag: JTAGIO): Unit = {
-    jtag.TCK  := pins.TCK.inputPin (pue = Bool(true)).asClock
-    jtag.TMS  := pins.TMS.inputPin (pue = Bool(true))
-    jtag.TDI  := pins.TDI.inputPin(pue = Bool(true))
-    jtag.TRSTn.foreach{t => t := pins.TRSTn.get.inputPin(pue = Bool(true))}
+    jtag.TCK  := pins.TCK.inputPin (pue = true.B).asClock
+    jtag.TMS  := pins.TMS.inputPin (pue = true.B)
+    jtag.TDI  := pins.TDI.inputPin(pue = true.B)
+    jtag.TRSTn.foreach{t => t := pins.TRSTn.get.inputPin(pue = true.B)}
 
     pins.TDO.outputPin(jtag.TDO.data)
     pins.TDO.o.oe := jtag.TDO.driven

--- a/src/main/scala/devices/jtag/JTAGPins.scala
+++ b/src/main/scala/devices/jtag/JTAGPins.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.jtag
 
-import Chisel._
+import chisel3._ 
 
 // ------------------------------------------------------------
 // SPI, UART, etc are with their respective packages,

--- a/src/main/scala/devices/mockaon/MockAON.scala
+++ b/src/main/scala/devices/mockaon/MockAON.scala
@@ -1,8 +1,7 @@
 package sifive.blocks.devices.mockaon
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import chisel3.Module
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
@@ -21,13 +20,13 @@ case class MockAONParams(
 }
 
 class MockAONPMUIO extends Bundle {
-  val vddpaden = Bool(OUTPUT)
-  val dwakeup = Bool(INPUT)
+  val vddpaden = Output(Bool())
+  val dwakeup = Input(Bool())
 }
 
 class MockAONMOffRstIO extends Bundle {
-  val hfclkrst = Bool(OUTPUT)
-  val corerst = Bool(OUTPUT)
+  val hfclkrst = Output(Bool())
+  val corerst = Output(Bool())
 }
 
 trait HasMockAONBundleContents extends Bundle {
@@ -37,15 +36,15 @@ trait HasMockAONBundleContents extends Bundle {
 
   // This goes out to wrapper
   // to be combined to create aon_rst.
-  val wdog_rst = Bool(OUTPUT)
+  val wdog_rst = Output(Bool())
 
   // This goes out to wrapper
   // and comes back as our clk
-  val lfclk = Clock(OUTPUT)
+  val lfclk = Output(Clock())
 
   val pmu = new MockAONPMUIO
 
-  val lfextclk = Clock(INPUT)
+  val lfextclk = Input(Clock())
 
   val resetCauses = new ResetCauses().asInput
 }
@@ -64,7 +63,7 @@ trait HasMockAONModuleContents extends Module with HasRegMap {
   io.moff <> pmu.io.control
   io.pmu.vddpaden := pmu.io.control.vddpaden
   pmu.io.wakeup.dwakeup := io.pmu.dwakeup
-  pmu.io.wakeup.awakeup := Bool(false)
+  pmu.io.wakeup.awakeup := false.B
   pmu.io.wakeup.rtc := rtc.io.ip(0)
   pmu.io.resetCauses := io.resetCauses
   val pmuRegMap = {
@@ -83,7 +82,7 @@ trait HasMockAONModuleContents extends Module with HasRegMap {
   // If there are multiple lfclks to choose from, we can mux them here.
   io.lfclk := io.lfextclk
 
-  val backupRegs = Seq.fill(c.nBackupRegs)(Reg(UInt(width = c.regBytes * 8)))
+  val backupRegs = Seq.fill(c.nBackupRegs)(Reg(UInt((c.regBytes * 8).W)))
   val backupRegMap =
     for ((reg, i) <- backupRegs.zipWithIndex)
       yield (c.backupRegOffset + c.regBytes*i) -> Seq(RegField(reg.getWidth, RegReadFn(reg), RegWriteFn(reg)))

--- a/src/main/scala/devices/mockaon/MockAON.scala
+++ b/src/main/scala/devices/mockaon/MockAON.scala
@@ -46,7 +46,7 @@ trait HasMockAONBundleContents extends Bundle {
 
   val lfextclk = Input(Clock())
 
-  val resetCauses = new ResetCauses().asInput
+  val resetCauses = Input(new ResetCauses())
 }
 
 trait HasMockAONModuleContents extends Module with HasRegMap {

--- a/src/main/scala/devices/mockaon/MockAON.scala
+++ b/src/main/scala/devices/mockaon/MockAON.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.mockaon
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.mockaon
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.devices.debug.HasPeripheryDebug
 import freechips.rocketchip.devices.tilelink.CanHavePeripheryCLINT

--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.mockaon
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.devices.debug.HasPeripheryDebug
@@ -37,13 +37,13 @@ trait HasPeripheryMockAONModuleImp extends LazyModuleImp with HasPeripheryMockAO
 
   // Explicit clock & reset are unused in MockAONWrapper.
   // Tie  to check this assumption.
-  outer.aon.module.clock := Bool(false).asClock
-  outer.aon.module.reset := Bool(true)
+  outer.aon.module.clock := false.B.asClock
+  outer.aon.module.reset := true.B
 
   // Synchronize the external toggle into the clint
   val rtc_sync = SynchronizerShiftReg(outer.aon.module.io.rtc.asUInt.asBool, 3, Some("rtc"))
-  val rtc_last = Reg(init = Bool(false), next=rtc_sync)
-  val rtc_tick = Reg(init = Bool(false), next=(rtc_sync & (~rtc_last)))
+  val rtc_last = RegNext(rtc_sync, false.B)
+  val rtc_tick = RegNext(rtc_sync & (~rtc_last), false.B)
 
   outer.clintOpt.foreach { clint =>
     clint.module.io.rtcTick := rtc_tick

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.mockaon
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -52,8 +52,8 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new MockAONWrapperBundle {
-      val rtc  = Clock(OUTPUT)
-      val ndreset = Bool(INPUT)
+      val rtc  = Output(Clock())
+      val ndreset = Input(Bool())
     })
 
     val aon_io = aon.module.io
@@ -64,12 +64,12 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     // -----------------------------------------------
 
     // ERST
-    val erst = ~pins.erst_n.inputPin(pue = Bool(true))
+    val erst = ~pins.erst_n.inputPin(pue = true.B)
     aon_io.resetCauses.erst := erst
     aon_io.resetCauses.wdogrst := aon_io.wdog_rst
 
     // PORRST
-    val porrst = Bool(false) // TODO
+    val porrst = false.B // TODO
     aon_io.resetCauses.porrst := porrst
 
     //--------------------------------------------------
@@ -90,7 +90,7 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     // Note that the actual mux lives inside AON itself.
     // Therefore, the lfclk which comes out of AON is the
     // true clock that AON and AONWrapper are running off of.
-    val lfextclk = pins.lfextclk.inputPin(pue=Bool(true))
+    val lfextclk = pins.lfextclk.inputPin(pue=true.B)
     aon_io.lfextclk := lfextclk.asClock
 
     // Drive AON's clock and Reset
@@ -121,13 +121,13 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     // Note that aon.moff.corerst is synchronous
     // to aon.module.clock, so this is safe.
     isolation.module.io.iso_out := aon.module.io.moff.corerst
-    isolation.module.io.iso_in  := Bool(true)
+    isolation.module.io.iso_in  := true.B
 
     //--------------------------------------------------
     // PMU <--> pins Interface
     //--------------------------------------------------
 
-    val dwakeup_n_async = pins.pmu.dwakeup_n.inputPin(pue=Bool(true))
+    val dwakeup_n_async = pins.pmu.dwakeup_n.inputPin(pue=true.B)
 
     val dwakeup_deglitch = Module (new DeglitchShiftRegister(3))
     dwakeup_deglitch.clock := lfclk
@@ -151,9 +151,9 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
 
 class IsoZero extends Module {
   val io = new Bundle {
-    val in = Bool(INPUT)
-    val iso = Bool(INPUT)
-    val out = Bool(OUTPUT)
+    val in = Input(Bool())
+    val iso = Input(Bool())
+    val out = Output(Bool())
   }
   io.out := io.in & ~io.iso
 }

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -113,7 +113,7 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     // Note that aon.moff.corerst is synchronous
     // to aon.module.clock, so this is safe.
     val crossing_slave_reset  = ResetCatchAndSync(lfclk,
-      aon.module.io.moff.corerst | aon.module.reset)
+      aon.module.io.moff.corerst | aon.module.reset.asBool)
 
     crossing.module.clock := lfclk
     crossing.module.reset := crossing_slave_reset

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.mockaon
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/mockaon/PMU.scala
+++ b/src/main/scala/devices/mockaon/PMU.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.mockaon
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 import sifive.blocks.util.SRLatch
 

--- a/src/main/scala/devices/mockaon/PMU.scala
+++ b/src/main/scala/devices/mockaon/PMU.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.mockaon
 
 import chisel3._
-import chisel3.util.{Valid, log2Ceil, OHToUInt}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 import sifive.blocks.util.SRLatch
@@ -31,7 +31,7 @@ class PMUSignals extends Bundle {
 
 class PMUInstruction extends Bundle {
   val sigs = new PMUSignals
-  val dt = UInt(width = 4)
+  val dt = UInt(4.W)
 }
 
 class PMUConfig(wakeupProgramIn: Seq[Int],
@@ -57,85 +57,86 @@ class PMURegs(c: PMUConfig) extends Bundle {
   val sleepProgram = Vec(c.programLength, new SlaveRegIF(32))
 }
 
-class PMUCore(c: PMUConfig)(resetIn: Bool) extends Module(_reset = resetIn) {
+class PMUCore(c: PMUConfig)(resetIn: Bool) extends Module() {
   val io = new Bundle {
-    val wakeup = new WakeupCauses().asInput
+    val wakeup = Input(new WakeupCauses())
     val control = Valid(new PMUSignals)
     val resetCause = Input(UInt(log2Ceil(new ResetCauses().getWidth).W))
     val regs = new PMURegs(c)
   }
-
-  val run = RegInit(true.B)
-  val awake = RegInit(true.B)
-  val unlocked = {
-    val writeAny = WatchdogTimer.writeAnyExceptKey(io.regs, io.regs.key)
-    RegEnable(io.regs.key.write.bits === WatchdogTimer.key && !writeAny, false.B, io.regs.key.write.valid || writeAny)
-  }
-  val wantSleep = RegEnable(true.B, false.B, io.regs.sleep.write.valid && unlocked)
-  val pc = RegInit(0.U(log2Ceil(c.programLength).W))
-  val wakeupCause = RegInit(0.U(log2Ceil(c.nWakeupCauses).W))
-  val ie = RegEnable(io.regs.ie.write.bits, io.regs.ie.write.valid && unlocked) | 1 /* POR always enabled */
-
-  val insnWidth = new PMUInstruction().getWidth
-  val wakeupProgram = c.wakeupProgram.map(v => RegInit(v.U(insnWidth.W)))
-  val sleepProgram = c.sleepProgram.map(v => RegInit(v.U(insnWidth.W)))
-  val insnBits = Mux(awake, wakeupProgram(pc), sleepProgram(pc))
-  val insn = insnBits.asTypeOf(new PMUInstruction())
-
-  val count = RegInit(0.U((1 << insn.dt.getWidth).W))
-  val tick = (count ^ (count + 1))(insn.dt)
-  val npc = pc +& 1
-  val last = npc >= c.programLength
-  io.control.valid := run && !last && tick
-  io.control.bits := insn.sigs
-
-  when (run) {
-    count := count + 1
-    when (tick) {
-      count := 0
-
-      require(isPow2(c.programLength))
-      run := !last
-      pc := npc
+  withReset(resetIn) {
+    val run = RegInit(true.B)
+    val awake = RegInit(true.B)
+    val unlocked = {
+      val writeAny = WatchdogTimer.writeAnyExceptKey(io.regs, io.regs.key)
+      RegEnable(io.regs.key.write.bits === WatchdogTimer.key.U && !writeAny, false.B, io.regs.key.write.valid || writeAny)
     }
-  }.otherwise {
-    val maskedWakeupCauses = ie & io.wakeup.asUInt
-    when (!awake && maskedWakeupCauses.orR) {
-      run := true
-      awake := true
-      wakeupCause := PriorityEncoder(maskedWakeupCauses)
-    }
-    when (awake && wantSleep) {
-      run := true
-      awake := false
-      wantSleep := false
-    }
-  }
+    val wantSleep = RegEnable(true.B, false.B, io.regs.sleep.write.valid && unlocked)
+    val pc = RegInit(0.U(log2Ceil(c.programLength).W))
+    val wakeupCause = RegInit(0.U(log2Ceil(c.nWakeupCauses).W))
+    val ie = RegEnable(io.regs.ie.write.bits, io.regs.ie.write.valid && unlocked) | 1.U /* POR always enabled */
 
-  io.regs.cause.read := wakeupCause | (io.resetCause << 8)
-  io.regs.ie.read := ie
-  io.regs.key.read := unlocked
-  io.regs.sleep.read := 0
+    val insnWidth = new PMUInstruction().getWidth
+    val wakeupProgram = c.wakeupProgram.map(v => RegInit(v.U(insnWidth.W)))
+    val sleepProgram = c.sleepProgram.map(v => RegInit(v.U(insnWidth.W)))
+    val insnBits = Mux(awake, wakeupProgram(pc), sleepProgram(pc))
+    val insn = insnBits.asTypeOf(new PMUInstruction())
 
-  for ((port, reg) <- (io.regs.wakeupProgram ++ io.regs.sleepProgram) zip (wakeupProgram ++ sleepProgram)) {
-    port.read := reg
-    when (port.write.valid && unlocked) { reg := port.write.bits }
+    val count = RegInit(0.U((1 << insn.dt.getWidth).W))
+    val tick = (count ^ (count + 1.U))(insn.dt)
+    val npc = pc +& 1.U
+    val last = npc >= c.programLength.U
+    io.control.valid := run && !last && tick
+    io.control.bits := insn.sigs
+
+    when (run) {
+      count := count + 1.U
+      when (tick) {
+        count := 0.U
+
+        require(isPow2(c.programLength))
+        run := !last
+        pc := npc
+      }
+    }.otherwise {
+      val maskedWakeupCauses = ie & io.wakeup.asUInt
+      when (!awake && maskedWakeupCauses.orR) {
+        run := true.B
+        awake := true.B
+        wakeupCause := PriorityEncoder(maskedWakeupCauses)
+      }
+      when (awake && wantSleep) {
+        run := true.B
+        awake := false.B
+        wantSleep := false.B
+      }
+    }
+
+    io.regs.cause.read := wakeupCause | (io.resetCause << 8)
+    io.regs.ie.read := ie
+    io.regs.key.read := unlocked
+    io.regs.sleep.read := 0.U
+
+    for ((port, reg) <- (io.regs.wakeupProgram ++ io.regs.sleepProgram) zip (wakeupProgram ++ sleepProgram)) {
+      port.read := reg
+      when (port.write.valid && unlocked) { reg := port.write.bits }
+    }
   }
 }
 
 class PMU(val c: PMUConfig) extends Module {
   val io = new Bundle {
-    val wakeup = new WakeupCauses().asInput
-    val control = new PMUSignals().asOutput
+    val wakeup = Input(new WakeupCauses())
+    val control = Output(new PMUSignals())
     val regs = new PMURegs(c)
-    val resetCauses = new ResetCauses().asInput
+    val resetCauses = Input(new ResetCauses())
   }
 
   val coreReset = RegNext(RegNext(reset))
-  val core = Module(new PMUCore(c)(resetIn = coreReset))
+  val core = Module(new PMUCore(c)(resetIn = coreReset.asBool))
 
   io <> core.io
-  core.io.wakeup.reset := false // this is implied by resetting the PMU
+  core.io.wakeup.reset := false.B // this is implied by resetting the PMU
 
   // during aonrst, hold all control signals high
   val latch = ~AsyncResetReg(~core.io.control.bits.asUInt, core.io.control.valid)

--- a/src/main/scala/devices/mockaon/RTC.scala
+++ b/src/main/scala/devices/mockaon/RTC.scala
@@ -1,9 +1,7 @@
 package sifive.blocks.devices.mockaon
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import Chisel.ImplicitConversions._
-import chisel3.Module
 import freechips.rocketchip.util.AsyncResetReg
 import freechips.rocketchip.regmapper.RegFieldDesc
 
@@ -17,9 +15,9 @@ class RTC extends Module with GenericTimer {
   protected def ncmp = 1
   protected def countEn = countAlways
   override protected lazy val ip = RegNext(elapsed)
-  override protected lazy val zerocmp = Bool(false)
+  override protected lazy val zerocmp = false.B
   protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlways, io.regs.cfg.write_countAlways && unlocked)(0)
-  protected lazy val feed = Bool(false)
+  protected lazy val feed = false.B
 
   override protected lazy val feed_desc = RegFieldDesc.reserved
   override protected lazy val key_desc = RegFieldDesc.reserved

--- a/src/main/scala/devices/mockaon/RTC.scala
+++ b/src/main/scala/devices/mockaon/RTC.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.mockaon
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.AsyncResetReg
 import freechips.rocketchip.regmapper.RegFieldDesc
 

--- a/src/main/scala/devices/mockaon/WatchdogTimer.scala
+++ b/src/main/scala/devices/mockaon/WatchdogTimer.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.mockaon
 
-import chisel3._ 
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.AsyncResetReg
 import freechips.rocketchip.regmapper.{RegFieldDesc}
@@ -30,15 +31,15 @@ class WatchdogTimer extends Module with GenericTimer {
     val corerstSynchronized = RegNext(RegNext(io.corerst))
     countAlways || (countAwake && !corerstSynchronized)
   }
-  override protected lazy val rsten = AsyncResetReg(io.regs.cfg.write.sticky, io.regs.cfg.write_sticky && unlocked)(0)
+  override protected lazy val rsten = AsyncResetReg(io.regs.cfg.write.sticky, io.regs.cfg.write_sticky && unlocked)(0.U)
   protected lazy val ip = RegEnable(VecInit(Seq(io.regs.cfg.write.ip(0) || elapsed(0))), (io.regs.cfg.write_ip(0) && unlocked) || elapsed(0))
   override protected lazy val unlocked = {
     val writeAny = WatchdogTimer.writeAnyExceptKey(io.regs, io.regs.key)
-    AsyncResetReg(io.regs.key.write.bits === WatchdogTimer.key && !writeAny, io.regs.key.write.valid || writeAny)(0)
+    AsyncResetReg(io.regs.key.write.bits === WatchdogTimer.key.U && !writeAny, io.regs.key.write.valid || writeAny)(0)
   }
   protected lazy val feed = {
     val food = 0xD09F00D
-    unlocked && io.regs.feed.write.valid && io.regs.feed.write.bits === food
+    unlocked && io.regs.feed.write.valid && io.regs.feed.write.bits === food.U
   }
 
   // The Scala Type-Chekcher seems to have a bug and I get a null pointer during the Scala compilation

--- a/src/main/scala/devices/mockaon/WatchdogTimer.scala
+++ b/src/main/scala/devices/mockaon/WatchdogTimer.scala
@@ -1,9 +1,7 @@
 package sifive.blocks.devices.mockaon
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import Chisel.ImplicitConversions._
-import chisel3.Module
 import freechips.rocketchip.util.AsyncResetReg
 import freechips.rocketchip.regmapper.{RegFieldDesc}
 
@@ -29,11 +27,11 @@ class WatchdogTimer extends Module with GenericTimer {
   protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlways, io.regs.cfg.write_countAlways && unlocked)(0)
   override protected lazy val countAwake = AsyncResetReg(io.regs.cfg.write.running, io.regs.cfg.write_running && unlocked)(0)
   protected lazy val countEn = {
-    val corerstSynchronized = Reg(next = Reg(next = io.corerst))
+    val corerstSynchronized = RegNext(RegNext(io.corerst))
     countAlways || (countAwake && !corerstSynchronized)
   }
   override protected lazy val rsten = AsyncResetReg(io.regs.cfg.write.sticky, io.regs.cfg.write_sticky && unlocked)(0)
-  protected lazy val ip = RegEnable(Vec(Seq(io.regs.cfg.write.ip(0) || elapsed(0))), (io.regs.cfg.write_ip(0) && unlocked) || elapsed(0))
+  protected lazy val ip = RegEnable(VecInit(Seq(io.regs.cfg.write.ip(0) || elapsed(0))), (io.regs.cfg.write_ip(0) && unlocked) || elapsed(0))
   override protected lazy val unlocked = {
     val writeAny = WatchdogTimer.writeAnyExceptKey(io.regs, io.regs.key)
     AsyncResetReg(io.regs.key.write.bits === WatchdogTimer.key && !writeAny, io.regs.key.write.valid || writeAny)(0)
@@ -58,11 +56,11 @@ class WatchdogTimer extends Module with GenericTimer {
   )
 
   class WatchDogTimerIO extends GenericTimerIO(regWidth, ncmp, maxcmp, scaleWidth, countWidth, cmpWidth) {
-    val corerst = Bool(INPUT)
-    val rst = Bool(OUTPUT)
+    val corerst = Input(Bool())
+    val rst = Output(Bool())
   }
   lazy val io = IO(new WatchDogTimerIO)
-  io.rst := AsyncResetReg(Bool(true), rsten && elapsed(0))
+  io.rst := AsyncResetReg(true.B, rsten && elapsed(0))
 }
 
 /*

--- a/src/main/scala/devices/mockaon/WatchdogTimer.scala
+++ b/src/main/scala/devices/mockaon/WatchdogTimer.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.mockaon
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.AsyncResetReg
 import freechips.rocketchip.regmapper.{RegFieldDesc}
 

--- a/src/main/scala/devices/msi/MSIMaster.scala
+++ b/src/main/scala/devices/msi/MSIMaster.scala
@@ -60,14 +60,14 @@ class MSIMaster(targets: Seq[MSITarget])(implicit p: Parameters) extends LazyMod
       data       = data << (shift << 3))._2
 
     // When A is sent, toggle our model of the remote state
-    when (io.a.fire()) {
+    when (io.a.fire) {
       remote := remote ^ select
       busy   := Bool(true)
     }
 
     // Sink D messages to clear busy
     io.d.ready := Bool(true)
-    when (io.d.fire()) {
+    when (io.d.fire) {
       busy := Bool(false)
     }
 

--- a/src/main/scala/devices/msi/MSIMaster.scala
+++ b/src/main/scala/devices/msi/MSIMaster.scala
@@ -2,7 +2,7 @@
 package sifive.blocks.devices.msi
 
 import chisel3._
-import chisel3.util.{Mux1H}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -37,7 +37,7 @@ class MSIMaster(targets: Seq[MSITarget])(implicit p: Parameters) extends LazyMod
       val m = masterEdge.manager.find(addr)
       require (m.isDefined, s"MSIMaster ${name} was pointed at address 0x${addr}%x which does not exist")
       require (m.get.supportsPutFull.contains(1), s"MSIMaster ${name} requires device ${m.get.name} supportPutFull of 1 byte (${m.get.supportsPutFull})")
-      UInt(addr)
+      addr.U
     }.take(interrupts.size max 1)
 
     require (interrupts.size <= targetMap.size, s"MSIMaster ${name} has more interrupts (${interrupts.size}) than addresses to use (${targetMap.size})")

--- a/src/main/scala/devices/msi/MSIMaster.scala
+++ b/src/main/scala/devices/msi/MSIMaster.scala
@@ -3,7 +3,6 @@ package sifive.blocks.devices.msi
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -1,7 +1,7 @@
 
 package sifive.blocks.devices.pinctrl
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 // This is the base class of things you "always"
@@ -16,18 +16,18 @@ class PinCtrl extends Bundle {
 // for the Pin
 abstract class Pin extends Bundle {
   val i = new Bundle {
-    val ival = Bool(INPUT)
-    val po   = Option(Bool(INPUT))
+    val ival = Input(Bool())
+    val po   = Option(Input(Bool()))
   }
   val o: PinCtrl
 
   // Must be defined by the subclasses
   def default(): Unit
-  def inputPin(pue: Bool = Bool(false)): Bool
+  def inputPin(pue: Bool = false.B): Bool
   def outputPin(signal: Bool,
-    pue: Bool = Bool(false),
-    ds: Bool = Bool(false),
-    ie: Bool = Bool(false)
+    pue: Bool = false.B,
+    ds: Bool = false.B,
+    ie: Bool = false.B
   ): Unit
   
 }
@@ -39,25 +39,25 @@ class BasePin extends Pin() {
   val o = new PinCtrl().asOutput
 
   def default(): Unit = {
-    this.o.oval := Bool(false)
-    this.o.oe   := Bool(false)
-    this.o.ie   := Bool(false)
+    this.o.oval := false.B
+    this.o.oe   := false.B
+    this.o.ie   := false.B
   }
 
-  def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
-    this.o.oval := Bool(false)
-    this.o.oe   := Bool(false)
-    this.o.ie   := Bool(true)
+  def inputPin(pue: Bool = false.B /*ignored*/): Bool = {
+    this.o.oval := false.B
+    this.o.oe   := false.B
+    this.o.ie   := true.B
     this.i.ival
   }
 
   def outputPin(signal: Bool,
-    pue: Bool = Bool(false), /*ignored*/
-    ds: Bool = Bool(false), /*ignored*/
-    ie: Bool = Bool(false)
+    pue: Bool = false.B, /*ignored*/
+    ds: Bool = false.B, /*ignored*/
+    ie: Bool = false.B
   ): Unit = {
     this.o.oval := signal
-    this.o.oe   := Bool(true)
+    this.o.oe   := true.B
     this.o.ie   := ie
   }
 }
@@ -77,37 +77,37 @@ class EnhancedPin  extends Pin() {
   val o = new EnhancedPinCtrl().asOutput
 
   def default(): Unit = {
-    this.o.oval := Bool(false)
-    this.o.oe   := Bool(false)
-    this.o.ie   := Bool(false)
-    this.o.ds   := Bool(false)
-    this.o.pue  := Bool(false)
-    this.o.ds1  := Bool(false)
-    this.o.ps   := Bool(false)
-    this.o.poe  := Bool(false)
+    this.o.oval := false.B
+    this.o.oe   := false.B
+    this.o.ie   := false.B
+    this.o.ds   := false.B
+    this.o.pue  := false.B
+    this.o.ds1  := false.B
+    this.o.ps   := false.B
+    this.o.poe  := false.B
 
   }
 
-  def inputPin(pue: Bool = Bool(false)): Bool = {
-    this.o.oval := Bool(false)
-    this.o.oe   := Bool(false)
+  def inputPin(pue: Bool = false.B): Bool = {
+    this.o.oval := false.B
+    this.o.oe   := false.B
     this.o.pue  := pue
-    this.o.ds   := Bool(false)
-    this.o.ie   := Bool(true)
-    this.o.ds1  := Bool(false)
-    this.o.ps   := Bool(false)
-    this.o.poe  := Bool(false)
+    this.o.ds   := false.B
+    this.o.ie   := true.B
+    this.o.ds1  := false.B
+    this.o.ps   := false.B
+    this.o.poe  := false.B
 
     this.i.ival
   }
 
   def outputPin(signal: Bool,
-    pue: Bool = Bool(false),
-    ds: Bool = Bool(false),
-    ie: Bool = Bool(false)
+    pue: Bool = false.B,
+    ds: Bool = false.B,
+    ie: Bool = false.B
   ): Unit = {
     this.o.oval := signal
-    this.o.oe   := Bool(true)
+    this.o.oe   := true.B
     this.o.pue  := pue
     this.o.ds   := ds
     this.o.ie   := ie
@@ -120,7 +120,7 @@ class EnhancedPin  extends Pin() {
     base_pin
   }
 
-  def nandInput(poe: Bool = Bool(true)) : Bool = {
+  def nandInput(poe: Bool = true.B) : Bool = {
     this.i.po.get
   }
 }

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -3,7 +3,6 @@ package sifive.blocks.devices.pinctrl
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 // This is the base class of things you "always"
 // want to control from a HW block.

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.pinctrl
 
 import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 // This is the base class of things you "always"
@@ -36,7 +37,7 @@ abstract class Pin extends Bundle {
 ////////////////////////////////////////////////////////////////////////////////////
 
 class BasePin extends Pin() {
-  val o = new PinCtrl().asOutput
+  val o = Output(new PinCtrl())
 
   def default(): Unit = {
     this.o.oval := false.B
@@ -74,7 +75,7 @@ class EnhancedPinCtrl extends PinCtrl {
 
 class EnhancedPin  extends Pin() {
 
-  val o = new EnhancedPinCtrl().asOutput
+  val o = Output(new EnhancedPinCtrl())
 
   def default(): Unit = {
     this.o.oval := false.B

--- a/src/main/scala/devices/porgen/PorGen.scala
+++ b/src/main/scala/devices/porgen/PorGen.scala
@@ -1,8 +1,7 @@
 package sifive.blocks.devices.porgen
 
 import Chisel._
-import chisel3.{Input,Output,dontTouch} //Parameterized black box
-import chisel3.experimental.IO
+import chisel3.{IO,Input,Output,dontTouch} //Parameterized black box
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._

--- a/src/main/scala/devices/porgen/PorGen.scala
+++ b/src/main/scala/devices/porgen/PorGen.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.porgen
 
-import Chisel._
-import chisel3.{Input,Output,dontTouch} //Parameterized black box
+import chisel3._ 
 import chisel3.experimental.IO
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/porgen/PorGen.scala
+++ b/src/main/scala/devices/porgen/PorGen.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.porgen
 
 import chisel3._
-import chisel3.{IO,Input,Output,dontTouch} //Parameterized black box
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.pwm
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.pwm
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.BaseSubsystem

--- a/src/main/scala/devices/pwm/PWMPins.scala
+++ b/src/main/scala/devices/pwm/PWMPins.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.pwm
 
-import Chisel._
-import chisel3.{withClockAndReset}
+import chisel3._ 
 import sifive.blocks.devices.pinctrl.{Pin}
 
 class PWMSignals[T <: Data](private val pingen: () => T, val c: PWMParams) extends Bundle {

--- a/src/main/scala/devices/spi/BlackBoxDelayBuffer.scala
+++ b/src/main/scala/devices/spi/BlackBoxDelayBuffer.scala
@@ -1,14 +1,14 @@
 package sifive.blocks.devices.spi
 
-import Chisel._
+import chisel3._ 
 import freechips.rocketchip.util.ShiftRegInit
 
 class BlackBoxDelayBuffer extends BlackBox {
   val io = IO(new Bundle() {
-  val in = UInt(INPUT,1.W) 
-  val sel = UInt(INPUT,5.W)
-  val out = UInt(OUTPUT, 1.W)
-  val mux_out = UInt(OUTPUT, 1.W)
+  val in = Input(UInt(1.W))
+  val sel = Input(UInt(5.W))
+  val out = Input(UInt(1.W))
+  val mux_out = Output(UInt(1.W))
   })
 }
 

--- a/src/main/scala/devices/spi/BlackBoxDelayBuffer.scala
+++ b/src/main/scala/devices/spi/BlackBoxDelayBuffer.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.spi
 
 import Chisel._
+import chisel3.BlackBox
 import freechips.rocketchip.util.ShiftRegInit
 
 class BlackBoxDelayBuffer extends BlackBox {

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.util._

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}

--- a/src/main/scala/devices/spi/SPIArbiter.scala
+++ b/src/main/scala/devices/spi/SPIArbiter.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import chisel3.util.{log2Ceil, Mux1H}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPIInnerIO(c: SPIParamsBase) extends SPILinkIO(c) {

--- a/src/main/scala/devices/spi/SPIArbiter.scala
+++ b/src/main/scala/devices/spi/SPIArbiter.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPIInnerIO(c: SPIParamsBase) extends SPILinkIO(c) {
   val lock = Output(Bool())

--- a/src/main/scala/devices/spi/SPIBundle.scala
+++ b/src/main/scala/devices/spi/SPIBundle.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 abstract class SPIBundle(val c: SPIParamsBase) extends Bundle
 

--- a/src/main/scala/devices/spi/SPIBundle.scala
+++ b/src/main/scala/devices/spi/SPIBundle.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.spi
 
-import chisel3._ 
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 abstract class SPIBundle(val c: SPIParamsBase) extends Bundle

--- a/src/main/scala/devices/spi/SPIBundle.scala
+++ b/src/main/scala/devices/spi/SPIBundle.scala
@@ -1,70 +1,70 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 abstract class SPIBundle(val c: SPIParamsBase) extends Bundle
 
 class SPIDataIO extends Bundle {
-  val i = Bool(INPUT)
-  val o = Bool(OUTPUT)
-  val ie = Bool(OUTPUT)
-  val oe = Bool(OUTPUT)
+  val i = Input(Bool())
+  val o = Output(Bool())
+  val ie = Output(Bool())
+  val oe = Output(Bool())
 }
 
 class SPIPortIO(c: SPIParamsBase) extends SPIBundle(c) {
-  val sck = Bool(OUTPUT)
+  val sck = Output(Bool())
   val dq = Vec(4, new SPIDataIO)
-  val cs = Vec(c.csWidth, Bool(OUTPUT))
+  val cs = Vec(c.csWidth, Output(Bool()))
 }
 
 trait HasSPIProtocol {
-  val proto = Bits(width = SPIProtocol.width)
+  val proto = Bits(SPIProtocol.width.W)
 }
 trait HasSPIEndian {
-  val endian = Bits(width = SPIEndian.width)
+  val endian = Bits(SPIEndian.width.W)
 }
 class SPIFormat(c: SPIParamsBase) extends SPIBundle(c)
     with HasSPIProtocol
     with HasSPIEndian {
-  val iodir = Bits(width = SPIDirection.width)
+  val iodir = Bits(SPIDirection.width.W)
 }
 
 trait HasSPILength extends SPIBundle {
-  val len = UInt(width = c.lengthBits)
+  val len = UInt(c.lengthBits.W)
 }
 
 class SPIClocking(c: SPIParamsBase) extends SPIBundle(c) {
-  val div = UInt(width = c.divisorBits)
+  val div = UInt(c.divisorBits.W)
   val pol = Bool()
   val pha = Bool()
 }
 
 class SPIChipSelect(c: SPIParamsBase) extends SPIBundle(c) {
-  val id = UInt(width = c.csIdBits)
+  val id = UInt(c.csIdBits.W)
   val dflt = Vec(c.csWidth, Bool())
 
   def toggle(en: Bool): Vec[Bool] = {
     val mask = en << id
     val out = Cat(dflt.reverse) ^ mask
-    Vec.tabulate(c.csWidth)(out(_))
+    VecInit.tabulate(c.csWidth)(out(_))
   }
 }
 
 trait HasSPICSMode {
-  val mode = Bits(width = SPICSMode.width)
+  val mode = Bits(SPICSMode.width.W)
 }
 
 class SPIDelay(c: SPIParamsBase) extends SPIBundle(c) {
-  val cssck = UInt(width = c.delayBits)
-  val sckcs = UInt(width = c.delayBits)
-  val intercs = UInt(width = c.delayBits)
-  val interxfr = UInt(width = c.delayBits)
+  val cssck = UInt(c.delayBits.W)
+  val sckcs = UInt(c.delayBits.W)
+  val intercs = UInt(c.delayBits.W)
+  val interxfr = UInt(c.delayBits.W)
 }
 
 class SPIWatermark(c: SPIParamsBase) extends SPIBundle(c) {
-  val tx = UInt(width = c.txDepthBits)
-  val rx = UInt(width = c.rxDepthBits)
+  val tx = UInt(c.txDepthBits.W)
+  val rx = UInt(c.rxDepthBits.W)
 }
 
 class SPIControl(c: SPIParamsBase) extends SPIBundle(c) {
@@ -83,22 +83,22 @@ object SPIControl {
     ctrl.fmt.proto := SPIProtocol.Single
     ctrl.fmt.iodir := SPIDirection.Rx
     ctrl.fmt.endian := SPIEndian.MSB
-    ctrl.fmt.len := UInt(math.min(c.frameBits, 8))
-    ctrl.sck.div := UInt(3)
-    ctrl.sck.pol := Bool(false)
-    ctrl.sck.pha := Bool(false)
-    ctrl.cs.id := UInt(0)
-    ctrl.cs.dflt.foreach { _ := Bool(true) }
+    ctrl.fmt.len := (math.min(c.frameBits, 8)).U
+    ctrl.sck.div := 3.U
+    ctrl.sck.pol := false.B
+    ctrl.sck.pha := false.B
+    ctrl.cs.id := 0.U
+    ctrl.cs.dflt.foreach { _ := true.B }
     ctrl.cs.mode := SPICSMode.Auto
-    ctrl.dla.cssck := UInt(1)
-    ctrl.dla.sckcs := UInt(1)
-    ctrl.dla.intercs := UInt(1)
-    ctrl.dla.interxfr := UInt(0)
-    ctrl.wm.tx := UInt(0)
-    ctrl.wm.rx := UInt(0)
-    ctrl.extradel.coarse := UInt(0)
-    ctrl.extradel.fine := UInt(0)
-    ctrl.sampledel.sd := UInt(c.defaultSampleDel)
+    ctrl.dla.cssck := 1.U
+    ctrl.dla.sckcs := 1.U
+    ctrl.dla.intercs := 1.U
+    ctrl.dla.interxfr := 0.U
+    ctrl.wm.tx := 0.U
+    ctrl.wm.rx := 0.U
+    ctrl.extradel.coarse := 0.U
+    ctrl.extradel.fine := 0.U
+    ctrl.sampledel.sd := c.defaultSampleDel.U
     ctrl
   }
 }

--- a/src/main/scala/devices/spi/SPIConsts.scala
+++ b/src/main/scala/devices/spi/SPIConsts.scala
@@ -1,12 +1,12 @@
 package sifive.blocks.devices.spi
 
-import Chisel._
+import chisel3._ 
 
 object SPIProtocol {
   val width = 2
-  def Single = UInt(0, width)
-  def Dual   = UInt(1, width)
-  def Quad   = UInt(2, width)
+  def Single = 0.U(width.W)
+  def Dual   = 1.U(width.W)
+  def Quad   = 2.U(width.W)
 
   def cases = Seq(Single, Dual, Quad)
   def decode(x: UInt): Seq[Bool] = cases.map(_ === x)
@@ -14,21 +14,21 @@ object SPIProtocol {
 
 object SPIDirection {
   val width = 1
-  def Rx = UInt(0, width)
-  def Tx = UInt(1, width)
+  def Rx = 0.U(width.W)
+  def Tx = 1.U(width.W)
 }
 
 object SPIEndian {
   val width = 1
-  def MSB = UInt(0, width)
-  def LSB = UInt(1, width)
+  def MSB = 0.U(width.W)
+  def LSB = 1.U(width.W)
 }
 
 object SPICSMode {
   val width = 2
-  def Auto = UInt(0, width)
-  def Hold = UInt(2, width)
-  def Off  = UInt(3, width)
+  def Auto = 0.U(width.W)
+  def Hold = 2.U(width.W)
+  def Off  = 3.U(width.W)
 }
 
 /*

--- a/src/main/scala/devices/spi/SPIFIFO.scala
+++ b/src/main/scala/devices/spi/SPIFIFO.scala
@@ -24,8 +24,8 @@ class SPIFIFO(c: SPIParamsBase) extends Module {
   txq.io.enq <> io.tx
   io.link.tx <> txq.io.deq
 
-  val fire_tx = io.link.tx.fire()
-  val fire_rx = io.link.rx.fire()
+  val fire_tx = io.link.tx.fire
+  val fire_rx = io.link.rx.fire
   val rxen = Reg(init = Bool(false))
 
   rxq.io.enq.valid := io.link.rx.valid && rxen

--- a/src/main/scala/devices/spi/SPIFIFO.scala
+++ b/src/main/scala/devices/spi/SPIFIFO.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Queue, Mux1H}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPIFIFOControl(c: SPIParamsBase) extends SPIBundle(c) {
@@ -13,8 +14,8 @@ class SPIFIFO(c: SPIParamsBase) extends Module {
   val io = new Bundle {
     val ctrl = new SPIFIFOControl(c).asInput
     val link = new SPIInnerIO(c)
-    val tx = Decoupled(Bits(width = c.frameBits)).flip
-    val rx = Decoupled(Bits(width = c.frameBits))
+    val tx = Flipped(Decoupled(Bits(c.frameBits.W)))
+    val rx = Decoupled(Bits(c.frameBits.W))
     val ip = new SPIInterrupts().asOutput
   }
 
@@ -26,14 +27,14 @@ class SPIFIFO(c: SPIParamsBase) extends Module {
 
   val fire_tx = io.link.tx.fire
   val fire_rx = io.link.rx.fire
-  val rxen = Reg(init = Bool(false))
+  val rxen = RegInit(false.B)
 
   rxq.io.enq.valid := io.link.rx.valid && rxen
   rxq.io.enq.bits := io.link.rx.bits
   io.rx <> rxq.io.deq
 
   when (fire_rx) {
-    rxen := Bool(false)
+    rxen := false.B
   }
   when (fire_tx) {
     rxen := (io.link.fmt.iodir === SPIDirection.Rx)
@@ -41,7 +42,7 @@ class SPIFIFO(c: SPIParamsBase) extends Module {
 
   val proto = SPIProtocol.decode(io.link.fmt.proto).zipWithIndex
   val cnt_quot = Mux1H(proto.map { case (s, i) => s -> (io.ctrl.fmt.len >> i) })
-  val cnt_rmdr = Mux1H(proto.map { case (s, i) => s -> (if (i > 0) io.ctrl.fmt.len(i-1, 0).orR else UInt(0)) })
+  val cnt_rmdr = Mux1H(proto.map { case (s, i) => s -> (if (i > 0) io.ctrl.fmt.len(i-1, 0).orR else 0.U) })
   io.link.fmt <> io.ctrl.fmt
   io.link.cnt := cnt_quot + cnt_rmdr
 
@@ -53,7 +54,7 @@ class SPIFIFO(c: SPIParamsBase) extends Module {
 
   io.link.cs.set := !cs_mode_off
   io.link.cs.clear := cs_update || (fire_tx && cs_clear)
-  io.link.cs.hold := Bool(false)
+  io.link.cs.hold := false.B
 
   io.link.lock := io.link.tx.valid || rxen
 

--- a/src/main/scala/devices/spi/SPIFIFO.scala
+++ b/src/main/scala/devices/spi/SPIFIFO.scala
@@ -12,11 +12,11 @@ class SPIFIFOControl(c: SPIParamsBase) extends SPIBundle(c) {
 
 class SPIFIFO(c: SPIParamsBase) extends Module {
   val io = new Bundle {
-    val ctrl = new SPIFIFOControl(c).asInput
+    val ctrl = Input(new SPIFIFOControl(c))
     val link = new SPIInnerIO(c)
     val tx = Flipped(Decoupled(Bits(c.frameBits.W)))
     val rx = Decoupled(Bits(c.frameBits.W))
-    val ip = new SPIInterrupts().asOutput
+    val ip = Output(new SPIInterrupts())
   }
 
   val txq = Module(new Queue(io.tx.bits, c.txDepth))

--- a/src/main/scala/devices/spi/SPIFIFO.scala
+++ b/src/main/scala/devices/spi/SPIFIFO.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._ 
 import chisel3.util.{Decoupled, Queue, Mux1H}
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPIFIFOControl(c: SPIParamsBase) extends SPIBundle(c) {
   val fmt = new SPIFormat(c) with HasSPILength

--- a/src/main/scala/devices/spi/SPIFlash.scala
+++ b/src/main/scala/devices/spi/SPIFlash.scala
@@ -85,7 +85,7 @@ class SPIFlashMap(c: SPIFlashParamsBase) extends Module {
   val cnt_done = cnt_last || cnt_zero
   when (cnt_en) {
     io.link.tx.valid := !cnt_zero
-    when (io.link.tx.fire()) {
+    when (io.link.tx.fire) {
       cnt := cnt - UInt(1)
     }
   }
@@ -160,7 +160,7 @@ class SPIFlashMap(c: SPIFlashParamsBase) extends Module {
     is (s_data_post) {
       io.link.tx.valid := Bool(false)
       io.data.valid := io.link.rx.valid
-      when (io.data.fire()) {
+      when (io.data.fire) {
         state := s_idle
       }
     }

--- a/src/main/scala/devices/spi/SPIFlash.scala
+++ b/src/main/scala/devices/spi/SPIFlash.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Mux1H, Enum}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 
@@ -43,15 +43,15 @@ object SPIFlashInsn {
 }
 
 class SPIFlashAddr(c: SPIFlashParamsBase) extends SPIBundle(c) {
-  val next = UInt(width = c.insnAddrBits)
-  val hold = UInt(width = c.insnAddrBits)
+  val next = UInt(c.insnAddrBits.W)
+  val hold = UInt(c.insnAddrBits.W)
 }
 
 class SPIFlashMap(c: SPIFlashParamsBase) extends Module {
   val io = new Bundle {
     val en = Input(Bool())
-    val ctrl = new SPIFlashControl(c).asInput
-    val addr = Decoupled(new SPIFlashAddr(c)).flip
+    val ctrl = Input(new SPIFlashControl(c))
+    val addr = Flipped(Decoupled(new SPIFlashAddr(c)))
     val data = Decoupled(UInt(c.frameBits.W))
     val link = new SPIInnerIO(c)
   }

--- a/src/main/scala/devices/spi/SPIFlash.scala
+++ b/src/main/scala/devices/spi/SPIFlash.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 
 

--- a/src/main/scala/devices/spi/SPIMedia.scala
+++ b/src/main/scala/devices/spi/SPIMedia.scala
@@ -84,7 +84,7 @@ class SPIMedia(c: SPIParamsBase) extends Module {
 
           op.valid := io.link.tx.valid
           io.link.tx.ready := op.ready
-          when (op.fire()) {
+          when (op.fire) {
             state := s_interxfr
           }
         }

--- a/src/main/scala/devices/spi/SPIMedia.scala
+++ b/src/main/scala/devices/spi/SPIMedia.scala
@@ -1,22 +1,23 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 
 class SPILinkIO(c: SPIParamsBase) extends SPIBundle(c) {
-  val tx = Decoupled(Bits(width = c.frameBits))
-  val rx = Valid(Bits(width = c.frameBits)).flip
+  val tx = Decoupled(Bits(c.frameBits.W))
+  val rx = Flipped(Valid(Bits(c.frameBits.W)))
 
-  val cnt = UInt(OUTPUT, c.countBits)
+  val cnt = Output(UInt(c.countBits.W))
   val fmt = new SPIFormat(c).asOutput
   val cs = new Bundle {
-    val set = Bool(OUTPUT)
-    val clear = Bool(OUTPUT) // Deactivate CS
-    val hold = Bool(OUTPUT) // Supress automatic CS deactivation
+    val set = Output(Bool())
+    val clear = Output(Bool()) // Deactivate CS
+    val hold = Output(Bool()) // Supress automatic CS deactivation
   }
-  val active = Bool(INPUT)
-  val disableOE = c.oeDisableDummy.option(Bool(OUTPUT)) // disable oe during dummy cycles in flash mode
+  val active = Input(Bool())
+  val disableOE = c.oeDisableDummy.option(Output(Bool())) // disable oe during dummy cycles in flash mode
 }
 
 class SPIMedia(c: SPIParamsBase) extends Module {
@@ -29,7 +30,7 @@ class SPIMedia(c: SPIParamsBase) extends Module {
       val extradel = new SPIExtraDelay(c).asInput
       val sampledel = new SPISampleDelay(c).asInput
     }
-    val link = new SPILinkIO(c).flip
+    val link = Flipped(new SPILinkIO(c))
   }
 
   val phy = Module(new SPIPhysical(c))
@@ -39,36 +40,36 @@ class SPIMedia(c: SPIParamsBase) extends Module {
   phy.io.ctrl.sampledel := io.ctrl.sampledel
 
   private val op = phy.io.op
-  op.valid := Bool(true)
+  op.valid := true.B
   op.bits.fn := SPIMicroOp.Delay
-  op.bits.stb := Bool(false)
+  op.bits.stb := false.B
   op.bits.cnt := io.link.cnt
   op.bits.data := io.link.tx.bits
   op.bits.disableOE.foreach(_ := io.link.disableOE.get)
 
-  val cs = Reg(io.ctrl.cs)
+  val cs = RegNext(io.ctrl.cs)
   val cs_set = Reg(Bool())
   val cs_active = io.ctrl.cs.toggle(io.link.cs.set)
   val cs_update = (cs_active.asUInt =/= cs.dflt.asUInt)
 
-  val clear = Reg(init = Bool(false))
-  val cs_assert = Reg(init = Bool(false))
+  val clear = RegInit(false.B)
+  val cs_assert = RegInit(false.B)
   val cs_deassert = clear || (cs_update && !io.link.cs.hold)
 
   clear := clear || (io.link.cs.clear && cs_assert)
 
-  val continuous = (io.ctrl.dla.interxfr === UInt(0))
+  val continuous = (io.ctrl.dla.interxfr === 0.U)
 
   io.port.sck := phy.io.port.sck
   io.port.dq <> phy.io.port.dq
   io.port.cs := cs.dflt
 
   io.link.rx := phy.io.rx
-  io.link.tx.ready := Bool(false)
+  io.link.tx.ready := false.B
   io.link.active := cs_assert
 
-  val (s_main :: s_interxfr :: s_intercs :: Nil) = Enum(UInt(), 3)
-  val state = Reg(init = s_main)
+  val (s_main :: s_interxfr :: s_intercs :: Nil) = Enum(3)
+  val state = RegInit(s_main)
 
   switch (state) {
     is (s_main) {
@@ -80,7 +81,7 @@ class SPIMedia(c: SPIParamsBase) extends Module {
           }
         } .otherwise {
           op.bits.fn := SPIMicroOp.Transfer
-          op.bits.stb := Bool(true)
+          op.bits.stb := true.B
 
           op.valid := io.link.tx.valid
           io.link.tx.ready := op.ready
@@ -92,14 +93,14 @@ class SPIMedia(c: SPIParamsBase) extends Module {
         // Assert CS
         op.bits.cnt := io.ctrl.dla.cssck
         when (op.ready) {
-          cs_assert := Bool(true)
+          cs_assert := true.B
           cs_set := io.link.cs.set
           cs.dflt := cs_active
         }
       } .otherwise {
         // Idle
-        op.bits.cnt := UInt(0)
-        op.bits.stb := Bool(true)
+        op.bits.cnt := 0.U
+        op.bits.stb := true.B
         cs := io.ctrl.cs
       }
     }
@@ -116,9 +117,9 @@ class SPIMedia(c: SPIParamsBase) extends Module {
     is (s_intercs) {
       // Deassert CS
       op.bits.cnt := io.ctrl.dla.intercs
-      op.bits.stb := Bool(true)
-      cs_assert := Bool(false)
-      clear := Bool(false)
+      op.bits.stb := true.B
+      cs_assert := false.B
+      clear := false.B
       when (op.ready) {
         cs.dflt := cs.toggle(cs_set)
         state := s_main

--- a/src/main/scala/devices/spi/SPIMedia.scala
+++ b/src/main/scala/devices/spi/SPIMedia.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Valid}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 
@@ -10,7 +10,7 @@ class SPILinkIO(c: SPIParamsBase) extends SPIBundle(c) {
   val rx = Flipped(Valid(Bits(c.frameBits.W)))
 
   val cnt = Output(UInt(c.countBits.W))
-  val fmt = new SPIFormat(c).asOutput
+  val fmt = Output(new SPIFormat(c))
   val cs = new Bundle {
     val set = Output(Bool())
     val clear = Output(Bool()) // Deactivate CS
@@ -24,11 +24,11 @@ class SPIMedia(c: SPIParamsBase) extends Module {
   val io = new Bundle {
     val port = new SPIPortIO(c)
     val ctrl = new Bundle {
-      val sck = new SPIClocking(c).asInput
-      val dla = new SPIDelay(c).asInput
-      val cs = new SPIChipSelect(c).asInput
-      val extradel = new SPIExtraDelay(c).asInput
-      val sampledel = new SPISampleDelay(c).asInput
+      val sck = Input(new SPIClocking(c))
+      val dla = Input(new SPIDelay(c))
+      val cs = Input(new SPIChipSelect(c))
+      val extradel = Input(new SPIExtraDelay(c))
+      val sampledel = Input(new SPISampleDelay(c))
     }
     val link = Flipped(new SPILinkIO(c))
   }

--- a/src/main/scala/devices/spi/SPIMedia.scala
+++ b/src/main/scala/devices/spi/SPIMedia.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 
 class SPILinkIO(c: SPIParamsBase) extends SPIBundle(c) {

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.subsystem.{BaseSubsystem}

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Field
 import freechips.rocketchip.subsystem.{BaseSubsystem}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/spi/SPIPhysical.scala
+++ b/src/main/scala/devices/spi/SPIPhysical.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 
 class SPIMicroOp(c: SPIParamsBase) extends SPIBundle(c) {

--- a/src/main/scala/devices/spi/SPIPhysical.scala
+++ b/src/main/scala/devices/spi/SPIPhysical.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import chisel3.util.{Decoupled, Valid, Mux1H}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util._
 
@@ -43,7 +43,7 @@ class SPIPhyControl(c: SPIParamsBase) extends SPIBundle(c) {
 class SPIPhysical(c: SPIParamsBase) extends Module {
   val io = new SPIBundle(c) {
     val port = new SPIPortIO(c)
-    val ctrl = new SPIPhyControl(c).asInput
+    val ctrl = Input(new SPIPhyControl(c))
     val op = Flipped(Decoupled(new SPIMicroOp(c)))
     val rx = Valid(Bits(c.frameBits.W))
   }

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.{SynchronizerShiftReg}
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}
 

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -1,8 +1,7 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import chisel3.{withClockAndReset}
 import freechips.rocketchip.util.{SynchronizerShiftReg}
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}
 
@@ -18,13 +17,13 @@ class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPISignals(pi
 object SPIPinsFromPort {
   
   def apply[T <: Pin](pins: SPISignals[T], spi: SPIPortIO, clock: Clock, reset: Bool,
-    syncStages: Int = 0, driveStrength: Bool = Bool(false)) {
+    syncStages: Int = 0, driveStrength: Bool = false.B) {
 
     withClockAndReset(clock, reset) {
       pins.sck.outputPin(spi.sck, ds = driveStrength)
 
       (pins.dq zip spi.dq).zipWithIndex.foreach {case ((p, s), i) =>
-        p.outputPin(s.o, pue = Bool(true), ds = driveStrength)
+        p.outputPin(s.o, pue = true.B, ds = driveStrength)
         p.o.oe := s.oe
         p.o.ie := ~s.oe
         s.i := SynchronizerShiftReg(p.i.ival, syncStages, name = Some(s"spi_dq_${i}_sync"))

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -64,7 +64,7 @@ case class SPIParams(
 class SPITopModule(c: SPIParamsBase, outer: TLSPIBase)
     extends LazyModuleImp(outer) {
 
-  val ctrl = Reg(init = SPIControl.init(c))
+  val ctrl = RegInit(SPIControl.init(c))
   val fifo = Module(new SPIFIFO(c))
   val mac = Module(new SPIMedia(c))
 
@@ -78,7 +78,7 @@ class SPITopModule(c: SPIParamsBase, outer: TLSPIBase)
   mac.io.ctrl.dla := ctrl.dla
   mac.io.ctrl.cs <> ctrl.cs
 
-  val ie = Reg(init = new SPIInterrupts().fromBits(Bits(0)))
+  val ie = RegInit(0.U.asTypeOf(new SPIInterrupts())) 
   val ip = fifo.io.ip
   outer.interrupts(0) := (ip.txwm && ie.txwm) || (ip.rxwm && ie.rxwm)
 

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.spi
 
-import chisel3._ 
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.spi
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{log2Ceil, isPow2}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -58,11 +59,11 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
 
   private val (f, _) = outer.fnode.in(0)
   // Tie unused channels
-  f.b.valid := Bool(false)
-  f.c.ready := Bool(true)
-  f.e.ready := Bool(true)
+  f.b.valid := false.B
+  f.c.ready := true.B
+  f.e.ready := true.B
 
-  val a = Reg(f.a.bits)
+  val a = RegNext(f.a.bits)
   val a_msb = log2Ceil(c.fSize) - 1
 
   when (f.a.fire) {
@@ -78,8 +79,8 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
   f.d.valid := flash.io.data.valid
   flash.io.data.ready := f.d.ready
 
-  val insn = Reg(init = SPIFlashInsn.init(c))
-  val flash_en = Reg(init = Bool(true))
+  val insn = RegInit(SPIFlashInsn.init(c))
+  val flash_en = RegInit(true.B)
 
   flash.io.ctrl.insn := insn
   flash.io.ctrl.fmt <> ctrl.fmt

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.spi
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.spi
 
 import chisel3._ 
-import chisel3.util.{log2Ceil, isPow2}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -65,7 +65,7 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
   val a = Reg(f.a.bits)
   val a_msb = log2Ceil(c.fSize) - 1
 
-  when (f.a.fire()) {
+  when (f.a.fire) {
     a := f.a.bits
   }
 

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.stream
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.devices.stream
 
 import chisel3._ 
-import chisel3.util.{Decoupled, log2Up, Queue}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
@@ -77,7 +77,7 @@ abstract class PseudoStream(busWidthBytes: Int, val params: PseudoStreamParams)(
     )
 
     (nbports zip bports).zipWithIndex.map { case ((nb, b), idx) =>
-      val txq_arb = Module(new Arbiter(UInt(width = params.dataBits), 2))
+      val txq_arb = Module(new Arbiter(UInt(params.dataBits.W), 2))
     txq_arb.io.in(0) <> nb.txq
     txq_arb.io.in(1) <> b.txq
     port.channel(idx).txq <> txq_arb.io.out

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.devices.stream
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Decoupled, log2Up, Queue}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
@@ -21,8 +22,8 @@ case class PseudoStreamParams(
 }
 
 class PseudoStreamChannelIO(val params: PseudoStreamParams) extends Bundle {
-  val txq = Decoupled(UInt(width = params.dataBits))
-  val rxq = Decoupled(UInt(width = params.dataBits)).flip
+  val txq = Decoupled(UInt(params.dataBits.W))
+  val rxq = Flipped(Decoupled(UInt(params.dataBits.W)))
 }
 
 class PseudoStreamPortIO(val params: PseudoStreamParams) extends Bundle {

--- a/src/main/scala/devices/timer/Timer.scala
+++ b/src/main/scala/devices/timer/Timer.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.timer
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.subsystem.BaseSubsystem

--- a/src/main/scala/devices/timer/Timer.scala
+++ b/src/main/scala/devices/timer/Timer.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.devices.timer
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.uart
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/uart/UARTPins.scala
+++ b/src/main/scala/devices/uart/UARTPins.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.uart
 
 import chisel3._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
 import sifive.blocks.devices.pinctrl.{Pin}
 

--- a/src/main/scala/devices/uart/UARTRx.scala
+++ b/src/main/scala/devices/uart/UARTRx.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.uart
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/uart/UARTTx.scala
+++ b/src/main/scala/devices/uart/UARTTx.scala
@@ -65,10 +65,10 @@ class UARTTx(c: UARTParams) extends Module {
   val busy = (counter =/= 0.U)
   io.in.ready := io.en && !busy
   io.tx_busy := busy
-  when (io.in.fire()) {
+  when (io.in.fire) {
     printf("UART TX (%x): %c\n", io.in.bits, io.in.bits)
   }
-  when (io.in.fire() && plusarg_tx) {
+  when (io.in.fire && plusarg_tx) {
     if (c.includeParity) {
       val includebit9 = if (c.dataBits == 9) Mux(io.data8or9.get, false.B, io.in.bits(8)) else false.B
       val parity = Mux(io.enparity.get, includebit9 ^ io.in.bits(7,0).asBools.reduce(_ ^ _) ^ io.parity.get, true.B)

--- a/src/main/scala/devices/uart/UARTTx.scala
+++ b/src/main/scala/devices/uart/UARTTx.scala
@@ -2,7 +2,6 @@ package sifive.blocks.devices.uart
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/wdt/TLWDT.scala
+++ b/src/main/scala/devices/wdt/TLWDT.scala
@@ -1,9 +1,7 @@
 package sifive.blocks.devices.wdt
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import Chisel.ImplicitConversions._
-import chisel3.Module
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
@@ -27,8 +25,8 @@ case class WDTParams(
   regBytes: Int = 4) extends DeviceParams
 
 class WDTPortIO(val c: WDTParams) extends Bundle {
-  val corerst = Bool(INPUT)
-  val rst = Bool(OUTPUT)
+  val corerst = Input(Bool())
+  val rst = Output(Bool())
 }
 
 abstract class WDT(busWidthBytes: Int, val params: WDTParams)(implicit p: Parameters)

--- a/src/main/scala/devices/wdt/TLWDT.scala
+++ b/src/main/scala/devices/wdt/TLWDT.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.devices.wdt
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/ip/xilinx/ibufds_gte2/ibufds_gte2.scala
+++ b/src/main/scala/ip/xilinx/ibufds_gte2/ibufds_gte2.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.ip.xilinx.ibufds_gte2
 
 import Chisel._
+import chisel3.BlackBox
 
 //IP : xilinx unisim IBUFDS_GTE2
 //Differential Signaling Input Buffer

--- a/src/main/scala/ip/xilinx/ibufds_gte2/ibufds_gte2.scala
+++ b/src/main/scala/ip/xilinx/ibufds_gte2/ibufds_gte2.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.ip.xilinx.ibufds_gte2
 
-import Chisel._
+import chisel3._ 
 
 //IP : xilinx unisim IBUFDS_GTE2
 //Differential Signaling Input Buffer
@@ -8,11 +8,11 @@ import Chisel._
 
 class IBUFDS_GTE2 extends BlackBox {
   val io = new Bundle {
-    val O         = Bool(OUTPUT)
-    val ODIV2     = Bool(OUTPUT)
-    val CEB       = Bool(INPUT)
-    val I         = Bool(INPUT)
-    val IB        = Bool(INPUT)
+    val O         = Output(Bool())
+    val ODIV2     = Output(Bool())
+    val CEB       = Input(Bool())
+    val I         = Input(Bool())
+    val IB        = Input(Bool())
   }
 }
 

--- a/src/main/scala/util/AsyncDownCounter.scala
+++ b/src/main/scala/util/AsyncDownCounter.scala
@@ -1,27 +1,27 @@
 package sifive.blocks.util
 
-import Chisel._
-import chisel3.{BlackBox, RawModule, withClockAndReset}
+import chisel3._ 
+import chisel3.util.{log2Ceil}
 import freechips.rocketchip.util.{AsyncResetRegVec, AsyncResetReg}
 
 class AsyncDownCounter(clock: Clock, reset: Bool, value: Int)
     extends Module (_clock = clock, _reset = reset) {
   val io = new Bundle {
-    val done = Bool(OUTPUT)
+    val done = Output(Bool())
   }
 
-  val count_next = Wire(UInt(width = log2Ceil(value)))
+  val count_next = Wire(UInt(log2Ceil(value).W))
   val count = AsyncResetReg(
     updateData = count_next,
     resetData = value,
     name = "count_reg")
   val done_reg = AsyncResetReg(
-    updateData = (count === UInt(0)),
+    updateData = (count === 0.U),
     resetData = 0,
     name = "done_reg")
 
-  when (count > UInt(0)) {
-    count_next := count - UInt(1)
+  when (count > 0.U) {
+    count_next := count - 1.U
   } .otherwise {
     count_next := count
   }

--- a/src/main/scala/util/DeglitchShiftRegister.scala
+++ b/src/main/scala/util/DeglitchShiftRegister.scala
@@ -2,7 +2,6 @@ package sifive.blocks.util
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 //Allows us to specify a different clock for a shift register
 // and to force input to be high for > 1 cycle.

--- a/src/main/scala/util/DeglitchShiftRegister.scala
+++ b/src/main/scala/util/DeglitchShiftRegister.scala
@@ -1,14 +1,15 @@
 package sifive.blocks.util
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{ShiftRegisters}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 //Allows us to specify a different clock for a shift register
 // and to force input to be high for > 1 cycle.
 class DeglitchShiftRegister(shift: Int) extends Module {
   val io = new Bundle {
-    val d = Bool(INPUT)
-    val q = Bool(OUTPUT)
+    val d = Input(Bool())
+    val q = Output(Bool())
   }
   val sync = ShiftRegister(io.d, shift)
   val last = ShiftRegister(sync, 1)
@@ -21,7 +22,7 @@ object DeglitchShiftRegister {
     val deglitch = Module (new DeglitchShiftRegister(shift))
     name.foreach(deglitch.suggestName(_))
     deglitch.clock := clock
-    deglitch.reset := Bool(false)
+    deglitch.reset := false.B
     deglitch.io.d := d
     deglitch.io.q
   }

--- a/src/main/scala/util/DeglitchShiftRegister.scala
+++ b/src/main/scala/util/DeglitchShiftRegister.scala
@@ -1,7 +1,7 @@
 package sifive.blocks.util
 
 import chisel3._ 
-import chisel3.util.{ShiftRegisters}
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 //Allows us to specify a different clock for a shift register

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.util
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -1,7 +1,6 @@
 package sifive.blocks.util
 
 import chisel3._ 
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import org.chipsalliance.cde.config.{Field, Parameters}
 

--- a/src/main/scala/util/RegMapFIFO.scala
+++ b/src/main/scala/util/RegMapFIFO.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.util
 
 import chisel3._ 
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 

--- a/src/main/scala/util/RegMapFIFO.scala
+++ b/src/main/scala/util/RegMapFIFO.scala
@@ -1,6 +1,6 @@
 package sifive.blocks.util
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 
@@ -13,18 +13,18 @@ object NonBlockingEnqueue {
     require(regWidth > enqWidth)
     Seq(
       RegField(enqWidth,
-        RegReadFn(UInt(0)),
+        RegReadFn(0.U),
         RegWriteFn((valid, data) => {
           enq.valid := valid && !quash
           enq.bits := data
-          Bool(true)
+          true.B
         }), RegFieldDesc("data", "Transmit data", access=RegFieldAccessType.W)),
       RegField(regWidth - enqWidth - 1),
       RegField(1,
         !enq.ready,
         RegWriteFn((valid, data) =>  {
           quash := valid && data(0)
-          Bool(true)
+          true.B
         }), RegFieldDesc("full", "Transmit FIFO full", access=RegFieldAccessType.R, volatile=true)))
   }
 }
@@ -39,7 +39,7 @@ object NonBlockingDequeue {
       RegField.r(deqWidth,
         RegReadFn(ready => {
           deq.ready := ready
-          (Bool(true), deq.bits)
+          (true.B, deq.bits)
         }), RegFieldDesc("data", "Receive data", volatile=true)),
       RegField(regWidth - deqWidth - 1),
       RegField.r(1, !deq.valid,

--- a/src/main/scala/util/RegMapFIFO.scala
+++ b/src/main/scala/util/RegMapFIFO.scala
@@ -2,7 +2,6 @@ package sifive.blocks.util
 
 import chisel3._ 
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 
 // MSB indicates full status

--- a/src/main/scala/util/SRLatch.scala
+++ b/src/main/scala/util/SRLatch.scala
@@ -1,6 +1,7 @@
 package sifive.blocks.util
 
 import Chisel._
+import chisel3.BlackBox
 
 class SRLatch extends BlackBox {
   val io = new Bundle {

--- a/src/main/scala/util/SRLatch.scala
+++ b/src/main/scala/util/SRLatch.scala
@@ -1,12 +1,12 @@
 package sifive.blocks.util
 
-import Chisel._
+import chisel3._ 
 
 class SRLatch extends BlackBox {
   val io = new Bundle {
-    val set = Bool(INPUT)
-    val reset = Bool(INPUT)
-    val q = Bool(OUTPUT)
+    val set = Input(Bool())
+    val reset = Input(Bool())
+    val q = Output(Bool())
   }
 }
 

--- a/src/main/scala/util/SlaveRegIF.scala
+++ b/src/main/scala/util/SlaveRegIF.scala
@@ -2,7 +2,6 @@ package sifive.blocks.util
 
 import chisel3._ 
 import chisel3.util.{Valid}
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 
 class SlaveRegIF(private val w: Int) extends Bundle {

--- a/src/main/scala/util/SlaveRegIF.scala
+++ b/src/main/scala/util/SlaveRegIF.scala
@@ -1,18 +1,19 @@
 package sifive.blocks.util
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._ 
+import chisel3.util.{Valid}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 
 class SlaveRegIF(private val w: Int) extends Bundle {
-  val write = Valid(UInt(width = w)).flip
-  val read = UInt(OUTPUT, w)
+  val write = Flipped(Valid(UInt(w.W)))
+  val read = Output(UInt(w.W))
 
   def toRegField(desc: Option[RegFieldDesc] = None): RegField = {
     def writeFn(valid: Bool, data: UInt): Bool = {
       write.valid := valid
       write.bits := data
-      Bool(true)
+      true.B
     }
     RegField(w, RegReadFn(read), RegWriteFn((v, d) => writeFn(v, d)), desc)
   }

--- a/src/main/scala/util/Timer.scala
+++ b/src/main/scala/util/Timer.scala
@@ -2,7 +2,6 @@ package sifive.blocks.util
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.util.WideCounter
 


### PR DESCRIPTION
This PR is built upon #15 and #19. Bumped all the legacy Chisel2 syntax to Chisel5. And compile successfully on  https://github.com/chipsalliance/chisel/commit/e51fa08c7.