### PR TITLE
Create TLWDTPeriphery.scala and fix mis-aligned widths in WatchdogTimer.scala

### DIFF
--- a/src/main/scala/devices/mockaon/WatchdogTimer.scala
+++ b/src/main/scala/devices/mockaon/WatchdogTimer.scala
@@ -24,6 +24,7 @@ class WatchdogTimer extends Module with GenericTimer {
   protected def countWidth = 31
   protected def cmpWidth = 16
   protected def ncmp = 1
+  override protected def maxcmp: Int = 1
   protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlways, io.regs.cfg.write_countAlways && unlocked)(0)
   override protected lazy val countAwake = AsyncResetReg(io.regs.cfg.write.running, io.regs.cfg.write_running && unlocked)(0)
   protected lazy val countEn = {

--- a/src/main/scala/devices/wdt/TLWDTPeriphery.scala
+++ b/src/main/scala/devices/wdt/TLWDTPeriphery.scala
@@ -18,18 +18,18 @@ import sifive.blocks.devices.mockaon.WatchdogTimer
 case object PeripheryWDTKey extends Field[Seq[WDTParams]](Nil)
 
 trait HasPeripheryWDT { this: BaseSubsystem =>
-    val wdtNodes = p(PeripheryWDTKey).map { ps =>
-        WDTAttachParams(ps).attachTo(this).ioNode.makeSink()
-    }
+  val wdtNodes = p(PeripheryWDTKey).map { ps =>
+    WDTAttachParams(ps).attachTo(this).ioNode.makeSink()
+  }
 }
 
 trait HasPeripheryWDTBundle {
-    val wdt: Seq[WDTPortIO]
+  val wdt: Seq[WDTPortIO]
 }
 
 trait HasPeripheryWDTModuleImp extends LazyRawModuleImp with HasPeripheryWDTBundle{
-    val outer: HasPeripheryWDT
-    val wdt = outer.wdtNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"wdt_$i"))}
+  val outer: HasPeripheryWDT
+  val wdt = outer.wdtNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"wdt_$i"))}
 }
 
 /*

--- a/src/main/scala/devices/wdt/TLWDTPeriphery.scala
+++ b/src/main/scala/devices/wdt/TLWDTPeriphery.scala
@@ -1,0 +1,49 @@
+package sifive.blocks.devices.wdt
+
+import chisel3._
+
+import org.chipsalliance.cde.config.{Field, Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
+import freechips.rocketchip.prci._
+import freechips.rocketchip.regmapper._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.subsystem._
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.util._
+
+import sifive.blocks.util._
+import sifive.blocks.devices.mockaon.WatchdogTimer
+
+case object PeripheryWDTKey extends Field[Seq[WDTParams]](Nil)
+
+trait HasPeripheryWDT { this: BaseSubsystem =>
+    val wdtNodes = p(PeripheryWDTKey).map { ps =>
+        WDTAttachParams(ps).attachTo(this).ioNode.makeSink()
+    }
+}
+
+trait HasPeripheryWDTBundle {
+    val wdt: Seq[WDTPortIO]
+}
+
+trait HasPeripheryWDTModuleImp extends LazyRawModuleImp with HasPeripheryWDTBundle{
+    val outer: HasPeripheryWDT
+    val wdt = outer.wdtNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"wdt_$i"))}
+}
+
+/*
+   Copyright 2016 SiFive, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/

--- a/src/main/scala/util/Timer.scala
+++ b/src/main/scala/util/Timer.scala
@@ -179,7 +179,7 @@ trait GenericTimer {
   protected def gang: Vec[Bool] = VecInit.fill(ncmp){false.B}
   protected val scaleWidth = 4
   protected val regWidth = 32
-  val maxcmp = 4
+  protected def maxcmp: Int = 4
   require(ncmp <= maxcmp)
   require(ncmp > 0)
 


### PR DESCRIPTION
Created a TLWDTPeriphery.scala file since I wanted to use the wdt and it was missing. Then ran into this error

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at ... ()
	at chipyard.stage.phases.PreElaboration.$anonfun$transform$1(PreElaboration.scala:35)
	at ... ()
	at ... (Stack trace trimmed to user code only. Rerun with --full-stacktrace to see the full stack trace)
Caused by: chisel3.package$ChiselException: Connection between sink (WatchdogTimer.scale_io.regs.cfg.read.ip: IO[Bool[4]]) and source (WatchdogTimer.ip: Reg[Bool[1]]) failed @: Sink and Source are different length Vecs.
```

So, changed WatchdogTimer.scala and Timer.scala to be able to override `maxcmp` to solve the issue.