### PR TITLE
fixed IOF for GPIO alternate function Co-authored-by: Ethan Gao <doih…

### DIFF
--- a/src/main/scala/devices/gpio/IOF.scala
+++ b/src/main/scala/devices/gpio/IOF.scala
@@ -27,7 +27,7 @@ object IOFCtrl {
 // Package up the inputs and outputs
 // for the IOF
 class IOFPin extends Pin {
-  val o  = Output(IOFCtrl())
+  val o  = Output(new IOFCtrl())
 
   def default(): Unit = {
     this.o.oval  := false.B
@@ -57,7 +57,11 @@ class IOFPin extends Pin {
 // and drive the valid signal for the IOF.
 object BasePinToIOF {
   def apply(pin: BasePin, iof: IOFPin): Unit = {
-    iof <> pin
+    iof.o.oval := pin.o.oval
+    iof.o.oe := pin.o.oe
+    iof.o.ie := pin.o.ie
+
+    pin.i <> iof.i  
     iof.o.valid := true.B
   }
 }

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -3,6 +3,7 @@ package sifive.blocks.devices.pinctrl
 
 import chisel3._
 import chisel3.util._
+import chisel3.experimental.dataview._
 
 // This is the base class of things you "always"
 // want to control from a HW block.


### PR DESCRIPTION
The Rocket Chip GPIO Block has the functionality to connect up to two alternate functions to be multiplexed onto the GPIO by specifying includeIOF=true. However, this functionality was never updated during the transition from Chisel2 to Chisel3 which causes elaboration issues due to Chisel3's stricter handling of assignments. This pull request fixes this and allows pin multiplexing to function again